### PR TITLE
Add credential-based auth and secure workspace APIs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# MongoDB connection string (shared cluster provided in brief)
+MONGODB_URI=mongodb+srv://botuser:YpgSkQ4lUznDgZBj@cluster0.bjjageq.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0
+# Optional override for the logical database name (defaults to "bive")
+MONGODB_DB_NAME=bive
+
+# Session secrets and auth providers
+# Generate with: openssl rand -base64 32
+NEXTAUTH_SECRET=
+# NEXTAUTH_URL=http://localhost:3000
+
+# Demo IDs used for the prototype dashboards
+DEMO_DONOR_ID=user-donor-001
+DEMO_ORGANIZATION_ID=org-sunrise

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# production
+/.next
+/out
+
+# misc
+.DS_Store
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/README.md
+++ b/README.md
@@ -1,1 +1,91 @@
-# b+ive
+# B+ive
+
+B+ive is a consent-first blood-credit exchange network that synchronizes donors, recipients, hospitals, administrators, and government authorities. Credits earned by donating blood can be redeemed later by the donor or transferred—with explicit consent—to beneficiaries anywhere in the network.
+
+This repository now contains the initial Next.js/Tailwind application scaffold backed by MongoDB. Subsequent phases will layer in authentication, the credit ledger, consent workflows, emergency overrides, and observability per the architecture playbook.
+
+## Getting started
+
+1. **Install dependencies**
+
+   ```bash
+   npm install
+   ```
+
+2. **Create environment file**
+
+   Copy `.env.example` to `.env.local` and keep the provided `MONGODB_URI` (or replace with your own cluster). If your Atlas project uses a different logical database name, set `MONGODB_DB_NAME` (defaults to `bive`). Set `NEXTAUTH_SECRET` once authentication is introduced.
+   The prototype dashboards expect demo identifiers—adjust `DEMO_DONOR_ID` and `DEMO_ORGANIZATION_ID` if you seed different data.
+
+3. **Load sample data (optional but recommended)**
+
+   ```bash
+   npm run seed
+   ```
+
+   The script populates MongoDB with a donor, beneficiaries, organizations, inventory snapshots, consent requests, and an outstanding emergency override so the dashboards render realistic metrics.
+
+4. **Run the development server**
+
+   ```bash
+   npm run dev
+   ```
+
+   Visit [http://localhost:3000](http://localhost:3000) to explore the landing page, roadmap overview, and documentation portal.
+
+5. **Sign in to the workspace**
+
+   Open [http://localhost:3000/auth/login](http://localhost:3000/auth/login) and use one of the seeded demo accounts (default password `ChangeMe123!`):
+
+   | Role | Email |
+   | --- | --- |
+   | Admin | `admin@bive.demo` |
+   | Government | `gov@bive.demo` |
+   | Organization | `org@bive.demo` |
+   | Donor | `ritu.sharma@example.com` |
+
+   Once authenticated you can access `/workspace` and the action consoles. API routes also require a valid session.
+
+6. **Health check API**
+
+   The `/api/health` endpoint attempts a lightweight connection to MongoDB and returns the list of collections to verify connectivity.
+
+## API prototypes
+
+Early domain endpoints now cover the core Phase 2 ledger scenarios. They expect authenticated callers (not yet wired) to provide IDs that correspond to documents in MongoDB.
+
+| Endpoint | Method | Purpose |
+| --- | --- | --- |
+| `/api/donations` | `POST` | Record a donation event, incrementing donor credits and organizational inventory. |
+| `/api/consents` | `POST` | Create a consent request for a beneficiary to spend another user’s credits. |
+| `/api/consents/:requestId/decision` | `POST` | Approve or decline a consent request; approvals debit credits and log fulfillment transactions. |
+| `/api/emergency-overrides` | `POST` | Apply a single outstanding emergency override within the configured debt ceiling. |
+| `/api/ledger/:userId` | `GET` | Retrieve a user’s credit summary and recent transactions. |
+| `/api/inventory/:organizationId` | `GET` | View real-time credit holdings by blood type for an organization. |
+| `/api/exchanges` | `POST` | Log inter-organization `(bloodType, credit)` exchange proposals. |
+
+## Workspace prototypes
+
+- `/workspace` highlights the role-based dashboards planned for Phase 2.
+- `/workspace/admin` surfaces compliance metrics and emergency oversight tasks.
+- `/workspace/government` aggregates nationwide coverage, risk alerts, and inter-organization exchange activity.
+- `/workspace/organization` previews inventory tracking and exchange guidance.
+- `/workspace/donor` shows donor credit history, consent prompts, and emergency debt visibility.
+- `/workspace/actions` provides transaction forms to exercise the donation, consent, emergency, and exchange APIs.
+
+Seeded MongoDB data now powers these views. If collections are empty, the UI falls back to friendly prompts explaining how to populate the database.
+
+## Documentation
+
+- [Architecture Overview](docs/architecture.md)
+
+## Tech stack
+
+- **Frontend**: Next.js 14 (App Router), React 18, Tailwind CSS
+- **UI primitives**: Custom iconography (Headless UI planned for interactive components)
+- **Content**: `react-markdown` renders the architecture document inside the app
+- **Database**: MongoDB Atlas (connection utility in `lib/db/mongodb.ts`)
+
+## Roadmap alignment
+
+The landing page highlights the phased delivery plan. With the Phase 1 discovery outputs committed, the codebase now includes the foundational Phase 2 API layer described above. Upcoming work will harden authentication, surface these capabilities through role-aware dashboards, and expand auditing/observability tooling.

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,7 @@
+import NextAuth from "next-auth";
+
+import { authOptions } from "@/lib/auth/options";
+
+const handler = NextAuth(authOptions);
+
+export { handler as GET, handler as POST };

--- a/app/api/consents/[requestId]/decision/route.ts
+++ b/app/api/consents/[requestId]/decision/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest } from "next/server";
+
+import { jsonResponse, handleApiError } from "@/lib/api/responses";
+import { requireApiSession } from "@/lib/auth/api";
+import { UnauthorizedError } from "@/lib/domain/errors";
+import { respondToConsentRequest } from "@/lib/domain/services";
+import { consentDecisionSchema } from "@/lib/domain/schemas";
+
+type RouteContext = {
+  params: { requestId: string };
+};
+
+export async function POST(request: NextRequest, context: RouteContext) {
+  try {
+    const session = await requireApiSession();
+    const payload = await request.json();
+    const decision = consentDecisionSchema.parse(payload);
+    const actorId = session.user?.id;
+    const roles = session.user?.roles ?? [];
+
+    if (actorId && decision.actorId !== actorId && !roles.includes("admin")) {
+      throw new UnauthorizedError("You may only respond to your own consent requests");
+    }
+
+    const result = await respondToConsentRequest(context.params.requestId, decision);
+
+    return jsonResponse(result);
+  } catch (error) {
+    return handleApiError(error);
+  }
+}

--- a/app/api/consents/route.ts
+++ b/app/api/consents/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest } from "next/server";
+
+import { jsonResponse, handleApiError } from "@/lib/api/responses";
+import { requireApiRole } from "@/lib/auth/api";
+import { createConsentRequest } from "@/lib/domain/services";
+import { consentRequestSchema } from "@/lib/domain/schemas";
+
+export async function POST(request: NextRequest) {
+  try {
+    await requireApiRole(["organization", "admin"]);
+    const payload = await request.json();
+    const data = consentRequestSchema.parse(payload);
+    const result = await createConsentRequest(data);
+
+    return jsonResponse(result, { status: 201 });
+  } catch (error) {
+    return handleApiError(error);
+  }
+}

--- a/app/api/donations/route.ts
+++ b/app/api/donations/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest } from "next/server";
+
+import { jsonResponse, handleApiError } from "@/lib/api/responses";
+import { requireApiRole } from "@/lib/auth/api";
+import { recordDonation } from "@/lib/domain/services";
+import { donationInputSchema } from "@/lib/domain/schemas";
+
+export async function POST(request: NextRequest) {
+  try {
+    await requireApiRole(["organization", "admin"]);
+    const payload = await request.json();
+    const data = donationInputSchema.parse(payload);
+    const result = await recordDonation(data);
+
+    return jsonResponse(
+      {
+        transactionId: result.transactionId
+      },
+      { status: 201 }
+    );
+  } catch (error) {
+    return handleApiError(error);
+  }
+}

--- a/app/api/emergency-overrides/route.ts
+++ b/app/api/emergency-overrides/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest } from "next/server";
+
+import { jsonResponse, handleApiError } from "@/lib/api/responses";
+import { requireApiRole } from "@/lib/auth/api";
+import { UnauthorizedError } from "@/lib/domain/errors";
+import { applyEmergencyOverride } from "@/lib/domain/services";
+import { emergencyOverrideSchema } from "@/lib/domain/schemas";
+
+export async function POST(request: NextRequest) {
+  try {
+    const session = await requireApiRole(["admin", "government"]);
+    const payload = await request.json();
+    const data = emergencyOverrideSchema.parse(payload);
+
+    const actorId = session.user?.id;
+    if (actorId && data.initiatedBy !== actorId && !session.user?.roles.includes("admin")) {
+      throw new UnauthorizedError("Emergency overrides must be recorded by the acting administrator");
+    }
+
+    const result = await applyEmergencyOverride(data);
+
+    return jsonResponse(result, { status: 201 });
+  } catch (error) {
+    return handleApiError(error);
+  }
+}

--- a/app/api/exchanges/route.ts
+++ b/app/api/exchanges/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest } from "next/server";
+
+import { jsonResponse, handleApiError } from "@/lib/api/responses";
+import { requireApiRole } from "@/lib/auth/api";
+import { createExchangeProposal } from "@/lib/domain/services";
+import { exchangeProposalSchema } from "@/lib/domain/schemas";
+
+export async function POST(request: NextRequest) {
+  try {
+    await requireApiRole(["organization", "admin"]);
+    const payload = await request.json();
+    const data = exchangeProposalSchema.parse(payload);
+    const result = await createExchangeProposal(data);
+
+    return jsonResponse(result, { status: 201 });
+  } catch (error) {
+    return handleApiError(error);
+  }
+}

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+import { getDatabase } from "@/lib/db/mongodb";
+
+export async function GET() {
+  try {
+    const db = await getDatabase();
+    const collections = await db.listCollections().toArray();
+
+    return NextResponse.json({
+      status: "ok",
+      collections: collections.map((collection) => collection.name)
+    });
+  } catch (error) {
+    console.error("Health check failed", error);
+    return NextResponse.json({ status: "error" }, { status: 500 });
+  }
+}

--- a/app/api/inventory/[organizationId]/route.ts
+++ b/app/api/inventory/[organizationId]/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest } from "next/server";
+
+import { jsonResponse, handleApiError } from "@/lib/api/responses";
+import { requireApiSession } from "@/lib/auth/api";
+import { UnauthorizedError } from "@/lib/domain/errors";
+import { getInventoryForOrganization } from "@/lib/domain/services";
+
+type RouteContext = {
+  params: { organizationId: string };
+};
+
+export async function GET(_request: NextRequest, context: RouteContext) {
+  try {
+    const session = await requireApiSession();
+    const roles = session.user?.roles ?? [];
+    const organizationId = context.params.organizationId;
+
+    if (roles.includes("organization")) {
+      if (!session.user?.organizationId || session.user.organizationId !== organizationId) {
+        throw new UnauthorizedError("You can only view inventory for your organization");
+      }
+    } else if (!roles.some((role) => ["admin", "government"].includes(role))) {
+      throw new UnauthorizedError();
+    }
+
+    const result = await getInventoryForOrganization(context.params.organizationId);
+    return jsonResponse(result);
+  } catch (error) {
+    return handleApiError(error);
+  }
+}

--- a/app/api/ledger/[userId]/route.ts
+++ b/app/api/ledger/[userId]/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest } from "next/server";
+
+import { jsonResponse, handleApiError } from "@/lib/api/responses";
+import { requireApiSession } from "@/lib/auth/api";
+import { UnauthorizedError } from "@/lib/domain/errors";
+import { getLedgerSummary } from "@/lib/domain/services";
+
+type RouteContext = {
+  params: { userId: string };
+};
+
+export async function GET(_request: NextRequest, context: RouteContext) {
+  try {
+    const session = await requireApiSession();
+    const userId = context.params.userId;
+    const roles = session.user?.roles ?? [];
+
+    if (session.user?.id !== userId && !roles.some((role) => ["admin", "government"].includes(role))) {
+      throw new UnauthorizedError("You are not allowed to view this ledger");
+    }
+
+    const result = await getLedgerSummary(context.params.userId);
+    return jsonResponse(result);
+  } catch (error) {
+    return handleApiError(error);
+  }
+}

--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -1,0 +1,48 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+
+import { LoginForm } from "@/components/auth/LoginForm";
+import { authOptions } from "@/lib/auth/options";
+import { getServerSession } from "next-auth";
+
+interface LoginPageProps {
+  searchParams?: { [key: string]: string | string[] | undefined };
+}
+
+export default async function LoginPage({ searchParams }: LoginPageProps) {
+  const session = await getServerSession(authOptions);
+  const callbackUrlParam = typeof searchParams?.callbackUrl === "string" ? searchParams?.callbackUrl : undefined;
+
+  if (session) {
+    redirect(callbackUrlParam ?? "/workspace");
+  }
+
+  return (
+    <main className="mx-auto flex min-h-[80vh] max-w-3xl flex-col justify-center gap-12 px-6 py-12">
+      <section className="space-y-6 rounded-3xl border border-white/10 bg-white/5 p-8 text-slate-100">
+        <div>
+          <h1 className="text-2xl font-semibold text-white">Sign in to B+ive</h1>
+          <p className="mt-2 text-sm text-slate-300">
+            Use the credentials provisioned by the seed script to explore the role-aware workspace. All API routes require an
+            authenticated session.
+          </p>
+        </div>
+        <LoginForm callbackUrl={callbackUrlParam} />
+        <p className="text-xs text-slate-400">
+          Demo accounts (password <code className="rounded bg-black/40 px-1 py-0.5 text-[11px]">ChangeMe123!</code>):
+          <br />
+          <span className="font-medium text-white">Admin</span>: admin@bive.demo · <span>Role: admin</span>
+          <br />
+          <span className="font-medium text-white">Government</span>: gov@bive.demo · <span>Role: government</span>
+          <br />
+          <span className="font-medium text-white">Organization</span>: org@bive.demo · <span>Role: organization</span>
+          <br />
+          <span className="font-medium text-white">Donor</span>: ritu.sharma@example.com · <span>Role: donor</span>
+        </p>
+      </section>
+      <p className="text-center text-sm text-slate-300">
+        Want to learn more about the architecture? Review the <Link href="/docs/architecture" className="text-brand-accent">design playbook</Link>.
+      </p>
+    </main>
+  );
+}

--- a/app/docs/architecture/page.tsx
+++ b/app/docs/architecture/page.tsx
@@ -1,0 +1,33 @@
+import { promises as fs } from "fs";
+import path from "path";
+import { notFound } from "next/navigation";
+import ReactMarkdown from "react-markdown";
+
+async function loadArchitectureMarkdown() {
+  const filePath = path.join(process.cwd(), "docs", "architecture.md");
+
+  try {
+    const file = await fs.readFile(filePath, "utf-8");
+    return file;
+  } catch (error) {
+    console.error("Unable to load architecture.md", error);
+    return null;
+  }
+}
+
+export default async function ArchitecturePage() {
+  const markdown = await loadArchitectureMarkdown();
+
+  if (!markdown) {
+    notFound();
+  }
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-10 px-6 py-16">
+      <h1 className="text-4xl font-bold text-white">Architecture Overview</h1>
+      <div className="prose prose-invert prose-headings:text-brand-accent prose-a:text-brand-accent">
+        <ReactMarkdown>{markdown}</ReactMarkdown>
+      </div>
+    </div>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,21 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light;
+  background-color: #0f172a;
+}
+
+body {
+  @apply bg-slate-950 text-slate-100 min-h-screen antialiased;
+}
+
+a {
+  @apply text-brand-accent underline-offset-4 hover:underline;
+}
+
+.gradient-overlay {
+  background: radial-gradient(circle at top, rgba(255, 204, 213, 0.3), transparent 60%),
+              radial-gradient(circle at bottom, rgba(193, 18, 31, 0.4), transparent 55%);
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,26 @@
+import type { Metadata } from "next";
+import "./globals.css";
+import { AppProviders } from "@/components/providers/AppProviders";
+import { TopNav } from "@/components/layout/TopNav";
+
+export const metadata: Metadata = {
+  title: "B+ive | Blood Credit Exchange",
+  description:
+    "B+ive synchronizes donors, recipients, organizations, and government authorities through a consent-driven blood credit ledger."
+};
+
+export default function RootLayout({
+  children
+}: Readonly<{ children: React.ReactNode }>) {
+  return (
+    <html lang="en">
+      <body className="gradient-overlay min-h-screen">
+        <AppProviders>
+          <div className="absolute inset-0 -z-10 bg-slate-950/90" aria-hidden />
+          <TopNav />
+          <div className="pt-24">{children}</div>
+        </AppProviders>
+      </body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,116 @@
+import Link from "next/link";
+
+const stats = [
+  { id: 1, label: "Credits tracked", value: "100ml = 1 credit" },
+  { id: 2, label: "Organizations", value: "Hospitals & blood banks" },
+  { id: 3, label: "Emergency support", value: "Admin & govt overrides" }
+];
+
+export default function HomePage() {
+  return (
+    <main className="relative overflow-hidden">
+      <div className="absolute left-1/2 top-1/3 h-72 w-72 -translate-x-1/2 -translate-y-1/2 rounded-full bg-brand-primary/20 blur-3xl" />
+      <div className="absolute -left-24 bottom-10 h-64 w-64 rotate-12 rounded-full bg-brand-accent/20 blur-3xl" />
+      <div className="absolute -right-32 top-10 h-80 w-80 -rotate-12 rounded-full bg-brand-dark/20 blur-3xl" />
+
+      <section className="mx-auto flex min-h-screen max-w-6xl flex-col gap-16 px-6 pb-24 pt-32 md:flex-row md:items-center md:gap-24">
+        <div className="flex-1 space-y-10">
+          <span className="inline-flex items-center gap-2 rounded-full border border-brand-primary/40 bg-brand-primary/10 px-4 py-1 text-sm font-semibold uppercase tracking-wide text-brand-accent">
+            Synchronize blood generosity
+          </span>
+          <h1 className="text-4xl font-bold leading-tight text-white md:text-5xl lg:text-6xl">
+            A consent-first blood credit network for donors, recipients, and regulators
+          </h1>
+          <p className="max-w-xl text-lg text-slate-300">
+            B+ive keeps every drop accounted for—from donation to redemption—while empowering organizations to collaborate and governments to oversee policy compliance.
+          </p>
+          <div className="flex flex-wrap gap-4">
+            <Link
+              href="/docs/architecture"
+              className="inline-flex items-center gap-2 rounded-full bg-brand-primary px-6 py-3 text-base font-semibold text-white shadow-lg shadow-brand-primary/40 transition hover:bg-brand-dark"
+            >
+              Explore architecture
+              <span aria-hidden>→</span>
+            </Link>
+            <Link
+              href="/workspace"
+              className="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/5 px-6 py-3 text-base font-semibold text-white transition hover:bg-white/10"
+            >
+              Open workspace prototype
+              <span aria-hidden>⤳</span>
+            </Link>
+          </div>
+
+          <dl className="grid grid-cols-1 gap-6 sm:grid-cols-3">
+            {stats.map((item) => (
+              <div key={item.id} className="rounded-2xl border border-white/10 bg-white/5 p-4 text-sm text-slate-200">
+                <dt className="font-semibold text-white">{item.label}</dt>
+                <dd className="mt-1 text-lg text-brand-accent">{item.value}</dd>
+              </div>
+            ))}
+          </dl>
+        </div>
+
+        <div className="flex flex-1 items-center justify-center">
+          <div className="relative aspect-square w-full max-w-sm">
+            <div className="absolute inset-0 animate-pulse rounded-full bg-gradient-to-b from-brand-primary via-brand-dark to-black opacity-80" />
+            <div className="absolute inset-4 animate-[spin_18s_linear_infinite] rounded-full border border-white/10" />
+            <div className="absolute inset-10 rounded-full border border-white/10" />
+            <div className="absolute inset-0 flex items-center justify-center">
+              <div className="flex h-48 w-48 items-center justify-center rounded-full bg-brand-primary shadow-2xl shadow-brand-primary/50">
+                <span className="text-3xl font-bold text-white">B+</span>
+              </div>
+            </div>
+            <div className="absolute -bottom-10 left-1/2 flex w-72 -translate-x-1/2 flex-col gap-3 rounded-3xl border border-white/10 bg-slate-900/80 p-4 backdrop-blur">
+              <h2 className="text-sm font-semibold uppercase tracking-wider text-brand-accent">
+                Snapshot
+              </h2>
+              <p className="text-sm text-slate-300">
+                Track donor credits, request consent, and initiate emergency overrides in one unified workspace.
+              </p>
+              <div className="flex items-center gap-3 text-xs text-slate-400">
+                <span className="inline-flex items-center gap-1 rounded-full bg-brand-primary/20 px-3 py-1 text-brand-accent">
+                  Credits: 24
+                </span>
+                <span>Organizations: 12</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section
+        id="features"
+        className="mx-auto flex max-w-6xl flex-col gap-12 px-6 pb-32 text-slate-200"
+      >
+        <div className="space-y-4">
+          <h2 className="text-3xl font-semibold text-white">Phase-based delivery</h2>
+          <p className="max-w-3xl text-base text-slate-300">
+            Implementation follows the discovery roadmap captured in the architecture document. Phase one focuses on foundations—role-aware auth, MongoDB connectivity, and credit ledger scaffolding—before expanding into compliance and analytics.
+          </p>
+        </div>
+        <div className="grid gap-6 md:grid-cols-3">
+          {[
+            {
+              title: "Phase 1",
+              description: "Bootstrap auth, data models, and seed dashboards for administrators, organizations, and donors."
+            },
+            {
+              title: "Phase 2",
+              description: "Deliver consent-driven credit redemption, organization inventory, and inter-organization exchanges."
+            },
+            {
+              title: "Phase 3",
+              description: "Harden compliance: audit logs, emergency override enforcement, reporting, and observability."
+            }
+          ].map((item) => (
+            <article key={item.title} className="rounded-3xl border border-white/10 bg-white/5 p-6">
+              <h3 className="text-xl font-semibold text-brand-accent">{item.title}</h3>
+              <p className="mt-3 text-sm text-slate-300">{item.description}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/app/workspace/actions/page.tsx
+++ b/app/workspace/actions/page.tsx
@@ -1,0 +1,65 @@
+import { ActionCard } from "@/components/forms/ActionCard";
+import { CreateConsentRequestForm } from "@/components/forms/CreateConsentRequestForm";
+import { EmergencyOverrideForm } from "@/components/forms/EmergencyOverrideForm";
+import { ExchangeProposalForm } from "@/components/forms/ExchangeProposalForm";
+import { RecordDonationForm } from "@/components/forms/RecordDonationForm";
+import { RespondConsentForm } from "@/components/forms/RespondConsentForm";
+import { requireRole } from "@/lib/auth/session";
+import { config } from "@/lib/config";
+
+export default async function WorkspaceActionsPage() {
+  await requireRole(["admin", "organization"], "/workspace/actions");
+  const defaults = {
+    donorId: config.demo.donorId,
+    organizationId: config.demo.organizationId
+  };
+
+  return (
+    <div className="space-y-8">
+      <p className="text-sm text-slate-300">
+        Use these action consoles to exercise the phase-two Mongo-backed APIs directly. Each form calls the
+        Next.js API routes so you can validate request payloads, inspect audit logs, and refresh the dashboards
+        with live data.
+      </p>
+      <div className="grid gap-6 lg:grid-cols-2">
+        <ActionCard
+          title="Record a donation"
+          description="Post a donor credit, update the ledger, and sync organizational inventory in one transaction."
+        >
+          <RecordDonationForm
+            defaultDonorId={defaults.donorId}
+            defaultOrganizationId={defaults.organizationId}
+          />
+        </ActionCard>
+        <ActionCard
+          title="Request consent"
+          description="Ask a donor to release credits for a beneficiary, capturing contextual details for auditing."
+        >
+          <CreateConsentRequestForm
+            defaultOwnerId={defaults.donorId}
+            defaultOrganizationId={defaults.organizationId}
+          />
+        </ActionCard>
+        <ActionCard
+          title="Respond to consent"
+          description="Approve or decline pending consent requests. Approvals debit credits immediately."
+        >
+          <RespondConsentForm defaultActorId={defaults.donorId} />
+        </ActionCard>
+        <ActionCard
+          title="Apply emergency override"
+          description="Authorize a one-time negative balance when urgent care requires immediate blood allocation."
+        >
+          <EmergencyOverrideForm defaultOrganizationId={defaults.organizationId} />
+        </ActionCard>
+      </div>
+      <ActionCard
+        title="Log inter-organization exchange"
+        description="Capture paired credit swaps so compliance teams can reconcile blood-type specific agreements."
+        className="lg:col-span-2"
+      >
+        <ExchangeProposalForm defaultOrganizationId={defaults.organizationId} />
+      </ActionCard>
+    </div>
+  );
+}

--- a/app/workspace/admin/page.tsx
+++ b/app/workspace/admin/page.tsx
@@ -1,0 +1,89 @@
+import { requireRole } from "@/lib/auth/session";
+import { getAdminDashboardSnapshot } from "@/lib/dashboard/queries";
+
+import type { MetricTone, TimelineStatus } from "@/lib/dashboard/types";
+
+const toneClasses: Record<MetricTone, string> = {
+  positive: "text-emerald-300",
+  negative: "text-rose-300",
+  warning: "text-amber-300",
+  neutral: "text-slate-300"
+};
+
+const statusBullets: Record<TimelineStatus, string> = {
+  success: "bg-emerald-400",
+  warning: "bg-amber-400",
+  error: "bg-rose-500",
+  info: "bg-sky-400"
+};
+
+export default async function AdminWorkspace() {
+  await requireRole(["admin", "government"], "/workspace/admin");
+  const { metrics, timeline, tasks } = await getAdminDashboardSnapshot();
+
+  return (
+    <div className="space-y-12">
+      <section>
+        <h2 className="text-lg font-semibold text-white">Compliance snapshot</h2>
+        {metrics.length > 0 ? (
+          <div className="mt-4 grid gap-4 sm:grid-cols-3">
+            {metrics.map((metric) => (
+              <div key={metric.label} className="rounded-3xl border border-white/10 bg-white/5 p-5">
+                <p className="text-sm text-slate-300">{metric.label}</p>
+                <p className="mt-2 text-2xl font-semibold text-white">{metric.value}</p>
+                {metric.change ? (
+                  <p className={`mt-2 text-xs font-medium ${toneClasses[metric.tone ?? "neutral"]}`}>{metric.change}</p>
+                ) : null}
+              </div>
+            ))}
+          </div>
+        ) : (
+          <p className="mt-4 text-sm text-slate-300">
+            No compliance metrics are available yet. Seed the database to explore the live snapshot.
+          </p>
+        )}
+      </section>
+
+      <section className="grid gap-6 lg:grid-cols-[2fr,1fr]">
+        <div className="space-y-4 rounded-3xl border border-white/10 bg-white/5 p-6">
+          <div className="flex items-center justify-between">
+            <h3 className="text-lg font-semibold text-brand-accent">Latest activity</h3>
+            <span className="text-xs uppercase tracking-wide text-slate-400">Audit trail</span>
+          </div>
+          {timeline.length > 0 ? (
+            <ul className="space-y-4">
+              {timeline.map((event) => (
+                <li key={event.id} className="flex gap-3">
+                  <span className={`mt-1 h-2.5 w-2.5 rounded-full ${statusBullets[event.status ?? "info"]}`} aria-hidden />
+                  <div>
+                    <p className="font-medium text-white">{event.title}</p>
+                    <p className="text-sm text-slate-300">{event.description}</p>
+                    <p className="text-xs text-slate-400">{event.at}</p>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-sm text-slate-300">No recent ledger activity yet.</p>
+          )}
+        </div>
+        <aside className="space-y-4 rounded-3xl border border-white/10 bg-white/5 p-6">
+          <h3 className="text-lg font-semibold text-brand-accent">Next steps</h3>
+          {tasks.length > 0 ? (
+            <ul className="space-y-3 text-sm text-slate-300">
+              {tasks.map((task) => (
+                <li key={task.id} className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
+                  <p className="font-medium text-white">{task.title}</p>
+                  {task.detail ? <p className="text-xs text-slate-300">{task.detail}</p> : null}
+                  {task.at ? <p className="text-xs text-slate-400">{task.at}</p> : null}
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-sm text-slate-300">All compliance queues are clear.</p>
+          )}
+        </aside>
+      </section>
+    </div>
+  );
+}

--- a/app/workspace/donor/page.tsx
+++ b/app/workspace/donor/page.tsx
@@ -1,0 +1,106 @@
+import { config } from "@/lib/config";
+import { requireRole } from "@/lib/auth/session";
+import { getDonorDashboardSnapshot } from "@/lib/dashboard/queries";
+
+import type { MetricTone, TimelineStatus } from "@/lib/dashboard/types";
+
+const toneClasses: Record<MetricTone, string> = {
+  positive: "text-emerald-300",
+  negative: "text-rose-300",
+  warning: "text-amber-300",
+  neutral: "text-slate-300"
+};
+
+const statusBullets: Record<TimelineStatus, string> = {
+  success: "bg-emerald-400",
+  warning: "bg-amber-400",
+  error: "bg-rose-500",
+  info: "bg-sky-400"
+};
+
+export default async function DonorWorkspace() {
+  await requireRole(["donor", "recipient", "admin"], "/workspace/donor");
+  const donorId = config.demo.donorId;
+  const snapshot = await getDonorDashboardSnapshot(donorId);
+
+  return (
+    <div className="space-y-12">
+      <section>
+        <h2 className="text-lg font-semibold text-white">Credit overview</h2>
+        {snapshot.metrics.length > 0 ? (
+          <div className="mt-4 grid gap-4 sm:grid-cols-3">
+            {snapshot.metrics.map((metric) => (
+              <div key={metric.label} className="rounded-3xl border border-white/10 bg-white/5 p-5">
+                <p className="text-sm text-slate-300">{metric.label}</p>
+                <p className="mt-2 text-2xl font-semibold text-white">{metric.value}</p>
+                {metric.change ? (
+                  <p className={`mt-2 text-xs font-medium ${toneClasses[metric.tone ?? "neutral"]}`}>{metric.change}</p>
+                ) : null}
+              </div>
+            ))}
+          </div>
+        ) : (
+          <p className="mt-4 text-sm text-slate-300">
+            No credit metrics yet—seed the database to view a donor profile snapshot.
+          </p>
+        )}
+      </section>
+
+      <section className="grid gap-6 lg:grid-cols-[2fr,1fr]">
+        <div className="space-y-4 rounded-3xl border border-white/10 bg-white/5 p-6">
+          <div className="flex items-center justify-between">
+            <h3 className="text-lg font-semibold text-brand-accent">Recent activity</h3>
+            <span className="text-xs uppercase tracking-wide text-slate-400">Audit ready</span>
+          </div>
+          {snapshot.timeline.length > 0 ? (
+            <ul className="space-y-4">
+              {snapshot.timeline.map((event) => (
+                <li key={event.id} className="flex gap-3">
+                  <span className={`mt-1 h-2.5 w-2.5 rounded-full ${statusBullets[event.status ?? "info"]}`} aria-hidden />
+                  <div>
+                    <p className="font-medium text-white">{event.title}</p>
+                    <p className="text-sm text-slate-300">{event.description}</p>
+                    <p className="text-xs text-slate-400">{event.at}</p>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-sm text-slate-300">No recent ledger activity recorded yet.</p>
+          )}
+        </div>
+        <aside className="space-y-4 rounded-3xl border border-white/10 bg-white/5 p-6">
+          <h3 className="text-lg font-semibold text-brand-accent">Upcoming tasks</h3>
+          {snapshot.upcoming.length > 0 ? (
+            <ul className="space-y-3">
+              {snapshot.upcoming.map((item) => (
+                <li key={item.id} className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
+                  <p className="text-sm font-medium text-white">{item.title}</p>
+                  {item.detail ? <p className="text-xs text-slate-300">{item.detail}</p> : null}
+                  {item.at ? <p className="text-xs text-slate-400">{item.at}</p> : null}
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-sm text-slate-300">All tasks are complete—new requests will appear here.</p>
+          )}
+          <p className="text-xs text-slate-400">
+            Need emergency support? Reach out to administrators directly—the override ledger keeps repayment plans and due dates
+            transparent.
+          </p>
+        </aside>
+      </section>
+
+      <section className="rounded-3xl border border-dashed border-brand-primary/40 bg-brand-primary/10 p-6 text-sm text-slate-200">
+        <h3 className="text-lg font-semibold text-brand-accent">How consent works</h3>
+        <p className="mt-2">
+          When organizations request to spend your credits, you receive the full beneficiary context before approving. Declines
+          keep your balance untouched, while approvals trigger a real-time debit and confirmation receipt.
+        </p>
+        <p className="mt-4 text-xs text-slate-300">
+          Emergency overrides remain one-time debts—your dashboard highlights them in red until the balance returns to zero.
+        </p>
+      </section>
+    </div>
+  );
+}

--- a/app/workspace/government/page.tsx
+++ b/app/workspace/government/page.tsx
@@ -1,0 +1,145 @@
+import { requireRole } from "@/lib/auth/session";
+import { getGovernmentDashboardSnapshot } from "@/lib/dashboard/queries";
+import type { MetricTone, RiskLevel, TimelineStatus } from "@/lib/dashboard/types";
+
+const toneClasses: Record<MetricTone, string> = {
+  positive: "text-emerald-300",
+  warning: "text-amber-300",
+  negative: "text-rose-300",
+  neutral: "text-slate-300"
+};
+
+const statusBullets: Record<TimelineStatus, string> = {
+  success: "bg-emerald-400",
+  warning: "bg-amber-400",
+  error: "bg-rose-500",
+  info: "bg-sky-400"
+};
+
+const severityStyles: Record<RiskLevel, { badge: string; label: string }> = {
+  high: {
+    badge: "bg-rose-500/20 text-rose-100 border border-rose-400/40",
+    label: "High"
+  },
+  medium: {
+    badge: "bg-amber-500/20 text-amber-100 border border-amber-400/40",
+    label: "Medium"
+  },
+  low: {
+    badge: "bg-emerald-500/20 text-emerald-100 border border-emerald-400/30",
+    label: "Low"
+  }
+};
+
+export default async function GovernmentWorkspace() {
+  await requireRole(["government", "admin"], "/workspace/government");
+  const { metrics, timeline, risks, inventory } = await getGovernmentDashboardSnapshot();
+
+  return (
+    <div className="space-y-12">
+      <section>
+        <h2 className="text-lg font-semibold text-white">National coverage</h2>
+        {metrics.length > 0 ? (
+          <div className="mt-4 grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+            {metrics.map((metric) => (
+              <div key={metric.label} className="rounded-3xl border border-white/10 bg-white/5 p-5">
+                <p className="text-sm text-slate-300">{metric.label}</p>
+                <p className="mt-2 text-2xl font-semibold text-white">{metric.value}</p>
+                {metric.change ? (
+                  <p className={`mt-2 text-xs font-medium ${toneClasses[metric.tone ?? "neutral"]}`}>{metric.change}</p>
+                ) : null}
+              </div>
+            ))}
+          </div>
+        ) : (
+          <p className="mt-4 text-sm text-slate-300">
+            No national metrics yet—seed the MongoDB database to populate the government workspace.
+          </p>
+        )}
+      </section>
+
+      <section className="grid gap-6 lg:grid-cols-[2fr,1fr]">
+        <div className="space-y-4 rounded-3xl border border-white/10 bg-white/5 p-6">
+          <div className="flex items-center justify-between">
+            <h3 className="text-lg font-semibold text-brand-accent">Network timeline</h3>
+            <span className="text-xs uppercase tracking-wide text-slate-400">Compliance + exchanges</span>
+          </div>
+          {timeline.length > 0 ? (
+            <ul className="space-y-4">
+              {timeline.map((event) => (
+                <li key={event.id} className="flex gap-3">
+                  <span className={`mt-1 h-2.5 w-2.5 rounded-full ${statusBullets[event.status ?? "info"]}`} aria-hidden />
+                  <div>
+                    <p className="font-medium text-white">{event.title}</p>
+                    <p className="text-sm text-slate-300">{event.description}</p>
+                    <p className="text-xs text-slate-400">{event.at}</p>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-sm text-slate-300">No recent inter-organization or emergency activity captured yet.</p>
+          )}
+        </div>
+        <aside className="space-y-4 rounded-3xl border border-white/10 bg-white/5 p-6">
+          <h3 className="text-lg font-semibold text-brand-accent">Risk radar</h3>
+          {risks.length > 0 ? (
+            <ul className="space-y-3">
+              {risks.map((risk) => {
+                const severity = severityStyles[risk.severity];
+                return (
+                  <li key={risk.id} className={`rounded-2xl px-4 py-3 text-sm text-slate-200 ${severity.badge}`}>
+                    <div className="flex items-center justify-between gap-2">
+                      <p className="font-semibold text-white">{risk.title}</p>
+                      <span className="text-xs uppercase tracking-wide text-white/80">{severity.label}</span>
+                    </div>
+                    {risk.detail ? <p className="mt-1 text-xs text-slate-200/80">{risk.detail}</p> : null}
+                  </li>
+                );
+              })}
+            </ul>
+          ) : (
+            <p className="text-sm text-slate-300">All indicators are within expected thresholds.</p>
+          )}
+        </aside>
+      </section>
+
+      <section className="rounded-3xl border border-white/10 bg-white/5 p-6">
+        <div className="flex items-center justify-between">
+          <h3 className="text-lg font-semibold text-brand-accent">Inventory coverage by blood type</h3>
+          <span className="text-xs uppercase tracking-wide text-slate-400">Credits across organizations</span>
+        </div>
+        {inventory.length > 0 ? (
+          <div className="mt-4 overflow-hidden rounded-2xl border border-white/5">
+            <table className="min-w-full divide-y divide-white/10 text-sm text-slate-200">
+              <thead className="bg-white/5 text-xs uppercase text-slate-300">
+                <tr>
+                  <th className="px-4 py-3 text-left">Blood type</th>
+                  <th className="px-4 py-3 text-right">Credits in network</th>
+                  <th className="px-4 py-3 text-right">Organizations</th>
+                  <th className="px-4 py-3 text-left">Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                {inventory.map((row) => (
+                  <tr key={row.bloodType} className="odd:bg-white/[0.04]">
+                    <td className="px-4 py-3 font-medium text-white">{row.bloodType}</td>
+                    <td className="px-4 py-3 text-right">{row.totalCredits}</td>
+                    <td className="px-4 py-3 text-right">{row.organizations}</td>
+                    <td className={`px-4 py-3 text-left text-xs ${row.lowStock ? "text-amber-300" : "text-emerald-300"}`}>
+                      {row.lowStock ? "Low reserves" : "Healthy"}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : (
+          <p className="mt-4 text-sm text-slate-300">
+            Inventory has not been recorded yet. As organizations log donations, coverage by blood type appears here.
+          </p>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/app/workspace/layout.tsx
+++ b/app/workspace/layout.tsx
@@ -1,0 +1,26 @@
+import type { ReactNode } from "react";
+
+import { WorkspaceNav } from "@/components/dashboard/WorkspaceNav";
+import { requireSession } from "@/lib/auth/session";
+
+export default async function WorkspaceLayout({ children }: { children: ReactNode }) {
+  const session = await requireSession("/workspace");
+  const roles = session.user?.roles ?? [];
+  const name = session.user?.name ?? session.user?.email ?? "Member";
+
+  return (
+    <div className="mx-auto max-w-6xl space-y-10 px-6 pb-24 pt-4">
+      <header className="space-y-4">
+        <div className="space-y-2">
+          <h1 className="text-3xl font-semibold text-white md:text-4xl">Operations workspace</h1>
+          <p className="max-w-3xl text-base text-slate-300">
+            Welcome back, {name}. Explore role-specific dashboards and action consoles. Run live transactions against MongoDB,
+            then review how the consent-driven ledger, inventory insights, and emergency policies respond across each view.
+          </p>
+        </div>
+        <WorkspaceNav roles={roles} />
+      </header>
+      <section className="space-y-8">{children}</section>
+    </div>
+  );
+}

--- a/app/workspace/organization/page.tsx
+++ b/app/workspace/organization/page.tsx
@@ -1,0 +1,128 @@
+import { config } from "@/lib/config";
+import { requireRole } from "@/lib/auth/session";
+import { getOrganizationDashboardSnapshot } from "@/lib/dashboard/queries";
+
+import type { MetricTone, TimelineStatus } from "@/lib/dashboard/types";
+
+const toneClasses: Record<MetricTone, string> = {
+  positive: "text-emerald-300",
+  warning: "text-amber-300",
+  negative: "text-rose-300",
+  neutral: "text-slate-300"
+};
+
+const statusBullets: Record<TimelineStatus, string> = {
+  success: "bg-emerald-400",
+  warning: "bg-amber-400",
+  error: "bg-rose-500",
+  info: "bg-sky-400"
+};
+
+export default async function OrganizationWorkspace() {
+  await requireRole(["organization", "admin"], "/workspace/organization");
+  const organizationId = config.demo.organizationId;
+  const snapshot = await getOrganizationDashboardSnapshot(organizationId);
+
+  return (
+    <div className="space-y-12">
+      {snapshot.organization?.name ? (
+        <div className="rounded-3xl border border-white/10 bg-white/5 p-6">
+          <h2 className="text-xl font-semibold text-brand-accent">{snapshot.organization.name}</h2>
+          <p className="text-sm text-slate-300">
+            {snapshot.organization.city ? `${snapshot.organization.city} · ` : null}
+            {snapshot.organization.status ? snapshot.organization.status : "Status unknown"}
+          </p>
+        </div>
+      ) : null}
+
+      <section>
+        <h2 className="text-lg font-semibold text-white">Operational metrics</h2>
+        {snapshot.metrics.length > 0 ? (
+          <div className="mt-4 grid gap-4 sm:grid-cols-3">
+            {snapshot.metrics.map((metric) => (
+              <div key={metric.label} className="rounded-3xl border border-white/10 bg-white/5 p-5">
+                <p className="text-sm text-slate-300">{metric.label}</p>
+                <p className="mt-2 text-2xl font-semibold text-white">{metric.value}</p>
+                {metric.change ? (
+                  <p className={`mt-2 text-xs font-medium ${toneClasses[metric.tone ?? "neutral"]}`}>{metric.change}</p>
+                ) : null}
+              </div>
+            ))}
+          </div>
+        ) : (
+          <p className="mt-4 text-sm text-slate-300">
+            No operational metrics yet—seed the organization data to explore this view.
+          </p>
+        )}
+      </section>
+
+      <section className="grid gap-6 lg:grid-cols-[2fr,1fr]">
+        <div className="space-y-4 rounded-3xl border border-white/10 bg-white/5 p-6">
+          <div className="flex items-center justify-between">
+            <h3 className="text-lg font-semibold text-brand-accent">Inventory by blood type</h3>
+            <span className="text-xs uppercase tracking-wide text-slate-400">Synced with ledger</span>
+          </div>
+          {snapshot.inventory.length > 0 ? (
+            <div className="overflow-hidden rounded-2xl border border-white/5">
+              <table className="min-w-full divide-y divide-white/10 text-sm text-slate-200">
+                <thead className="bg-white/5 text-xs uppercase text-slate-300">
+                  <tr>
+                    <th className="px-4 py-3 text-left">Blood type</th>
+                    <th className="px-4 py-3 text-right">Credits</th>
+                    <th className="px-4 py-3 text-right">Units</th>
+                    <th className="px-4 py-3 text-left">Alerts</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {snapshot.inventory.map((row) => (
+                    <tr key={row.bloodType} className="odd:bg-white/[0.04]">
+                      <td className="px-4 py-3 font-medium text-white">{row.bloodType}</td>
+                      <td className="px-4 py-3 text-right">{row.credits}</td>
+                      <td className="px-4 py-3 text-right">{row.units}</td>
+                      <td className="px-4 py-3 text-left text-xs text-amber-300">
+                        {row.expiresSoon ? "Expiring soon" : "Stable"}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : (
+            <p className="text-sm text-slate-300">No inventory tracked for this organization yet.</p>
+          )}
+        </div>
+        <aside className="space-y-4 rounded-3xl border border-white/10 bg-white/5 p-6">
+          <h3 className="text-lg font-semibold text-brand-accent">Recent activity</h3>
+          {snapshot.timeline.length > 0 ? (
+            <ul className="space-y-4">
+              {snapshot.timeline.map((event) => (
+                <li key={event.id} className="flex gap-3">
+                  <span className={`mt-1 h-2.5 w-2.5 rounded-full ${statusBullets[event.status ?? "info"]}`} aria-hidden />
+                  <div>
+                    <p className="font-medium text-white">{event.title}</p>
+                    <p className="text-sm text-slate-300">{event.description}</p>
+                    <p className="text-xs text-slate-400">{event.at}</p>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-sm text-slate-300">No recent activity recorded for this organization.</p>
+          )}
+        </aside>
+      </section>
+
+      <section className="rounded-3xl border border-dashed border-brand-primary/40 bg-brand-primary/10 p-6 text-sm text-slate-200">
+        <h3 className="text-lg font-semibold text-brand-accent">Exchange playbook</h3>
+        <p className="mt-2">
+          Coordinate with partner organizations using paired credit trades, such as swapping <span className="font-semibold">2
+          O-</span> credits for <span className="font-semibold">3 A+</span> credits. The ledger tracks any imbalances and signals
+          administrators when make-up deliveries are due.
+        </p>
+        <p className="mt-4 text-xs text-slate-300">
+          Tip: capture negotiation notes in the exchange record so compliance teams can audit approvals later.
+        </p>
+      </section>
+    </div>
+  );
+}

--- a/app/workspace/page.tsx
+++ b/app/workspace/page.tsx
@@ -1,0 +1,42 @@
+import Link from "next/link";
+
+import { getCurrentSession } from "@/lib/auth/session";
+import { workspaceHighlights } from "@/lib/dashboard/constants";
+
+export default async function WorkspaceLanding() {
+  const session = await getCurrentSession();
+  const roles = session?.user?.roles ?? [];
+
+  const availableHighlights = workspaceHighlights.filter(
+    (item) => !item.roles || item.roles.some((role) => roles.includes(role))
+  );
+
+  if (availableHighlights.length === 0) {
+    return (
+      <div className="rounded-3xl border border-white/10 bg-white/5 p-6 text-sm text-slate-300">
+        Your account is provisioned, but it has not been assigned to any workspace. Contact an administrator to join an
+        organization or request access.
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid gap-6 md:grid-cols-3">
+      {availableHighlights.map((item) => (
+        <article key={item.role} className="flex flex-col gap-4 rounded-3xl border border-white/10 bg-white/5 p-6">
+          <div className="space-y-1">
+            <h2 className="text-xl font-semibold text-brand-accent">{item.role}</h2>
+            <p className="text-sm text-slate-300">{item.summary}</p>
+          </div>
+          <Link
+            href={item.href}
+            className="mt-auto inline-flex w-fit items-center gap-2 rounded-full bg-brand-primary px-4 py-2 text-sm font-semibold text-white transition hover:bg-brand-dark"
+          >
+            {item.cta}
+            <span aria-hidden>→</span>
+          </Link>
+        </article>
+      ))}
+    </div>
+  );
+}

--- a/components/auth/LoginForm.tsx
+++ b/components/auth/LoginForm.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useState } from "react";
+import { signIn } from "next-auth/react";
+import { useSearchParams } from "next/navigation";
+
+interface LoginFormProps {
+  callbackUrl?: string;
+}
+
+export function LoginForm({ callbackUrl }: LoginFormProps) {
+  const params = useSearchParams();
+  const [formState, setFormState] = useState({ email: "", password: "" });
+  const [status, setStatus] = useState<"idle" | "loading" | "error">("idle");
+  const [message, setMessage] = useState<string | null>(null);
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setStatus("loading");
+    setMessage(null);
+
+    const result = await signIn("credentials", {
+      redirect: false,
+      email: formState.email.trim(),
+      password: formState.password,
+      callbackUrl: callbackUrl || params.get("callbackUrl") || "/workspace"
+    });
+
+    if (!result) {
+      setStatus("error");
+      setMessage("Unexpected authentication response.");
+      return;
+    }
+
+    if (result.error) {
+      setStatus("error");
+      setMessage("Invalid email or password.");
+      return;
+    }
+
+    setStatus("idle");
+    window.location.href = result.url ?? "/workspace";
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6">
+      <div className="space-y-2">
+        <label htmlFor="email" className="text-sm font-medium text-slate-200">
+          Email
+        </label>
+        <input
+          id="email"
+          type="email"
+          required
+          autoComplete="email"
+          value={formState.email}
+          onChange={(event) => setFormState((prev) => ({ ...prev, email: event.target.value }))}
+          className="w-full rounded-2xl border border-white/10 bg-black/40 px-4 py-2 text-sm text-white placeholder-slate-400 focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary/40"
+        />
+      </div>
+      <div className="space-y-2">
+        <label htmlFor="password" className="text-sm font-medium text-slate-200">
+          Password
+        </label>
+        <input
+          id="password"
+          type="password"
+          required
+          autoComplete="current-password"
+          value={formState.password}
+          onChange={(event) => setFormState((prev) => ({ ...prev, password: event.target.value }))}
+          className="w-full rounded-2xl border border-white/10 bg-black/40 px-4 py-2 text-sm text-white placeholder-slate-400 focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary/40"
+        />
+      </div>
+      {status === "error" && message ? (
+        <p className="text-sm font-medium text-rose-300">{message}</p>
+      ) : null}
+      <button
+        type="submit"
+        disabled={status === "loading"}
+        className="w-full rounded-full bg-brand-primary px-4 py-2 text-sm font-semibold text-white transition hover:bg-brand-primary/90 disabled:opacity-70"
+      >
+        {status === "loading" ? "Signing in…" : "Sign in"}
+      </button>
+    </form>
+  );
+}

--- a/components/dashboard/WorkspaceNav.tsx
+++ b/components/dashboard/WorkspaceNav.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+const links: Array<{ href: string; label: string; roles?: string[] }> = [
+  { href: "/workspace", label: "Overview" },
+  { href: "/workspace/admin", label: "Admin", roles: ["admin", "government"] },
+  { href: "/workspace/government", label: "Government", roles: ["government", "admin"] },
+  { href: "/workspace/organization", label: "Organization", roles: ["organization", "admin"] },
+  { href: "/workspace/donor", label: "Donor", roles: ["donor", "recipient", "admin"] },
+  { href: "/workspace/actions", label: "Actions", roles: ["admin", "organization"] }
+];
+
+export function WorkspaceNav({ roles }: { roles: string[] }) {
+  const pathname = usePathname();
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      {links
+        .filter((link) => !link.roles || link.roles.some((role) => roles.includes(role)))
+        .map((link) => {
+          const isActive = pathname === link.href;
+
+          return (
+            <Link
+              key={link.href}
+              href={link.href}
+              className={`rounded-full px-4 py-2 text-sm font-semibold transition ${
+                isActive
+                  ? "bg-brand-primary text-white shadow-lg shadow-brand-primary/40"
+                  : "border border-white/10 bg-white/5 text-slate-200 hover:bg-white/10"
+              }`}
+            >
+              {link.label}
+            </Link>
+          );
+        })}
+    </div>
+  );
+}

--- a/components/forms/ActionCard.tsx
+++ b/components/forms/ActionCard.tsx
@@ -1,0 +1,22 @@
+import type { ReactNode } from "react";
+
+interface ActionCardProps {
+  title: string;
+  description: string;
+  children: ReactNode;
+  className?: string;
+}
+
+export function ActionCard({ title, description, children, className }: ActionCardProps) {
+  const baseClass =
+    "rounded-3xl border border-white/10 bg-white/[0.06] p-6 shadow-xl shadow-black/20 backdrop-blur";
+  const combinedClass = className ? `${baseClass} ${className}` : baseClass;
+
+  return (
+    <section className={combinedClass}>
+      <h2 className="text-lg font-semibold text-white">{title}</h2>
+      <p className="mt-2 text-sm text-slate-300">{description}</p>
+      <div className="mt-4 space-y-4">{children}</div>
+    </section>
+  );
+}

--- a/components/forms/CreateConsentRequestForm.tsx
+++ b/components/forms/CreateConsentRequestForm.tsx
@@ -1,0 +1,266 @@
+"use client";
+
+import { useState } from "react";
+
+type StatusState = "idle" | "submitting" | "success" | "error";
+
+type FormState = {
+  creditOwnerId: string;
+  beneficiaryId: string;
+  organizationId: string;
+  credits: string;
+  expiresAt: string;
+  requestedBloodType: string;
+  reason: string;
+  clinicalNotes: string;
+};
+
+interface CreateConsentRequestFormProps {
+  defaultOwnerId: string;
+  defaultOrganizationId: string;
+}
+
+const BLOOD_TYPES = ["", "A+", "A-", "B+", "B-", "AB+", "AB-", "O+", "O-"];
+
+export function CreateConsentRequestForm({
+  defaultOwnerId,
+  defaultOrganizationId
+}: CreateConsentRequestFormProps) {
+  const [form, setForm] = useState<FormState>({
+    creditOwnerId: defaultOwnerId,
+    beneficiaryId: "",
+    organizationId: defaultOrganizationId,
+    credits: "1",
+    expiresAt: "",
+    requestedBloodType: "",
+    reason: "",
+    clinicalNotes: ""
+  });
+  const [status, setStatus] = useState<{ state: StatusState; message?: string }>({ state: "idle" });
+
+  function updateField<K extends keyof FormState>(field: K, value: FormState[K]) {
+    setForm((prev) => ({ ...prev, [field]: value }));
+  }
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    const credits = Number.parseInt(form.credits, 10);
+    if (!Number.isInteger(credits) || credits <= 0) {
+      setStatus({ state: "error", message: "Credits must be a positive integer." });
+      return;
+    }
+
+    const payload: Record<string, unknown> = {
+      creditOwnerId: form.creditOwnerId.trim(),
+      beneficiaryId: form.beneficiaryId.trim(),
+      organizationId: form.organizationId.trim(),
+      credits
+    };
+
+    if (form.expiresAt) {
+      payload.expiresAt = new Date(form.expiresAt).toISOString();
+    }
+
+    const context: Record<string, string> = {};
+    if (form.requestedBloodType) {
+      context.requestedBloodType = form.requestedBloodType;
+    }
+    if (form.reason.trim()) {
+      context.reason = form.reason.trim();
+    }
+    if (form.clinicalNotes.trim()) {
+      context.clinicalNotes = form.clinicalNotes.trim();
+    }
+
+    if (Object.keys(context).length > 0) {
+      payload.context = context;
+    }
+
+    setStatus({ state: "submitting" });
+
+    try {
+      const response = await fetch("/api/consents", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload)
+      });
+
+      const body = await response.json().catch(() => ({}));
+
+      if (!response.ok) {
+        const message = typeof body.error === "string" ? body.error : "Unable to create consent request.";
+        setStatus({ state: "error", message });
+        return;
+      }
+
+      setStatus({
+        state: "success",
+        message:
+          typeof body.requestId === "string"
+            ? `Consent request ${body.requestId} created.`
+            : "Consent request created."
+      });
+
+      setForm((prev) => ({
+        ...prev,
+        beneficiaryId: "",
+        credits: "1",
+        expiresAt: "",
+        requestedBloodType: "",
+        reason: "",
+        clinicalNotes: ""
+      }));
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unexpected error while creating consent request.";
+      setStatus({ state: "error", message });
+    }
+  }
+
+  const isSubmitting = status.state === "submitting";
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="grid gap-4 md:grid-cols-2">
+        <div className="space-y-2">
+          <label htmlFor="creditOwnerId" className="text-sm font-medium text-slate-200">
+            Credit owner ID
+          </label>
+          <input
+            id="creditOwnerId"
+            name="creditOwnerId"
+            value={form.creditOwnerId}
+            onChange={(event) => updateField("creditOwnerId", event.target.value)}
+            required
+            className="w-full rounded-xl border border-white/10 bg-black/30 px-4 py-2 text-sm text-white placeholder-slate-400 focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary/40"
+          />
+        </div>
+        <div className="space-y-2">
+          <label htmlFor="beneficiaryId" className="text-sm font-medium text-slate-200">
+            Beneficiary ID
+          </label>
+          <input
+            id="beneficiaryId"
+            name="beneficiaryId"
+            value={form.beneficiaryId}
+            onChange={(event) => updateField("beneficiaryId", event.target.value)}
+            required
+            className="w-full rounded-xl border border-white/10 bg-black/30 px-4 py-2 text-sm text-white placeholder-slate-400 focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary/40"
+          />
+        </div>
+        <div className="space-y-2">
+          <label htmlFor="organizationId" className="text-sm font-medium text-slate-200">
+            Organization ID
+          </label>
+          <input
+            id="organizationId"
+            name="organizationId"
+            value={form.organizationId}
+            onChange={(event) => updateField("organizationId", event.target.value)}
+            required
+            className="w-full rounded-xl border border-white/10 bg-black/30 px-4 py-2 text-sm text-white placeholder-slate-400 focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary/40"
+          />
+        </div>
+        <div className="space-y-2">
+          <label htmlFor="credits" className="text-sm font-medium text-slate-200">
+            Credits requested
+          </label>
+          <input
+            id="credits"
+            name="credits"
+            type="number"
+            min={1}
+            step={1}
+            value={form.credits}
+            onChange={(event) => updateField("credits", event.target.value)}
+            required
+            className="w-full rounded-xl border border-white/10 bg-black/30 px-4 py-2 text-sm text-white focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary/40"
+          />
+        </div>
+        <div className="space-y-2">
+          <label htmlFor="expiresAt" className="text-sm font-medium text-slate-200">
+            Expires at
+          </label>
+          <input
+            id="expiresAt"
+            name="expiresAt"
+            type="datetime-local"
+            value={form.expiresAt}
+            onChange={(event) => updateField("expiresAt", event.target.value)}
+            className="w-full rounded-xl border border-white/10 bg-black/30 px-4 py-2 text-sm text-white focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary/40"
+          />
+        </div>
+        <div className="space-y-2">
+          <label htmlFor="requestedBloodType" className="text-sm font-medium text-slate-200">
+            Requested blood type
+          </label>
+          <select
+            id="requestedBloodType"
+            name="requestedBloodType"
+            value={form.requestedBloodType}
+            onChange={(event) => updateField("requestedBloodType", event.target.value)}
+            className="w-full rounded-xl border border-white/10 bg-black/30 px-4 py-2 text-sm text-white focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary/40"
+          >
+            {BLOOD_TYPES.map((type) => (
+              <option key={type || "none"} value={type}>
+                {type || "Any"}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="space-y-2 md:col-span-2">
+          <label htmlFor="reason" className="text-sm font-medium text-slate-200">
+            Reason shared with credit owner
+          </label>
+          <textarea
+            id="reason"
+            name="reason"
+            rows={3}
+            value={form.reason}
+            onChange={(event) => updateField("reason", event.target.value)}
+            placeholder="Explain why the credits are needed"
+            className="w-full rounded-xl border border-white/10 bg-black/30 px-4 py-2 text-sm text-white placeholder-slate-400 focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary/40"
+          />
+        </div>
+        <div className="space-y-2 md:col-span-2">
+          <label htmlFor="clinicalNotes" className="text-sm font-medium text-slate-200">
+            Clinical notes (internal)
+          </label>
+          <textarea
+            id="clinicalNotes"
+            name="clinicalNotes"
+            rows={3}
+            value={form.clinicalNotes}
+            onChange={(event) => updateField("clinicalNotes", event.target.value)}
+            placeholder="Optional details visible to auditors"
+            className="w-full rounded-xl border border-white/10 bg-black/30 px-4 py-2 text-sm text-white placeholder-slate-400 focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary/40"
+          />
+        </div>
+      </div>
+      <div className="flex items-center justify-between gap-4">
+        <button
+          type="submit"
+          disabled={isSubmitting}
+          className="inline-flex items-center justify-center rounded-full bg-brand-primary px-4 py-2 text-sm font-semibold text-white transition hover:bg-brand-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {isSubmitting ? "Creating request…" : "Create request"}
+        </button>
+        <p className="text-xs text-slate-400">
+          The credit owner receives the beneficiary profile before approving.
+        </p>
+      </div>
+      <div aria-live="polite" className="min-h-[1.5rem] text-sm">
+        {status.state === "success" && status.message ? (
+          <p className="rounded-xl border border-emerald-400/30 bg-emerald-500/10 px-4 py-2 text-emerald-200">
+            {status.message}
+          </p>
+        ) : null}
+        {status.state === "error" && status.message ? (
+          <p className="rounded-xl border border-rose-500/40 bg-rose-500/10 px-4 py-2 text-rose-200">
+            {status.message}
+          </p>
+        ) : null}
+      </div>
+    </form>
+  );
+}

--- a/components/forms/EmergencyOverrideForm.tsx
+++ b/components/forms/EmergencyOverrideForm.tsx
@@ -1,0 +1,260 @@
+"use client";
+
+import { useState } from "react";
+
+type StatusState = "idle" | "submitting" | "success" | "error";
+
+type FormState = {
+  beneficiaryId: string;
+  organizationId: string;
+  initiatedBy: string;
+  credits: string;
+  justification: string;
+  repaymentPlan: string;
+  repaymentDueAt: string;
+  debtCeilingCredits: string;
+};
+
+interface EmergencyOverrideFormProps {
+  defaultOrganizationId: string;
+}
+
+export function EmergencyOverrideForm({ defaultOrganizationId }: EmergencyOverrideFormProps) {
+  const [form, setForm] = useState<FormState>({
+    beneficiaryId: "",
+    organizationId: defaultOrganizationId,
+    initiatedBy: "",
+    credits: "1",
+    justification: "",
+    repaymentPlan: "",
+    repaymentDueAt: "",
+    debtCeilingCredits: "3"
+  });
+  const [status, setStatus] = useState<{ state: StatusState; message?: string }>({ state: "idle" });
+
+  function updateField<K extends keyof FormState>(field: K, value: FormState[K]) {
+    setForm((prev) => ({ ...prev, [field]: value }));
+  }
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    const credits = Number.parseInt(form.credits, 10);
+    const ceiling = Number.parseInt(form.debtCeilingCredits, 10);
+
+    if (!Number.isInteger(credits) || credits <= 0) {
+      setStatus({ state: "error", message: "Override credits must be a positive integer." });
+      return;
+    }
+
+    if (!Number.isInteger(ceiling) || ceiling <= 0) {
+      setStatus({ state: "error", message: "Debt ceiling must be a positive integer." });
+      return;
+    }
+
+    if (!form.justification.trim()) {
+      setStatus({ state: "error", message: "Provide a justification for the override." });
+      return;
+    }
+
+    const payload: Record<string, unknown> = {
+      beneficiaryId: form.beneficiaryId.trim(),
+      organizationId: form.organizationId.trim(),
+      initiatedBy: form.initiatedBy.trim(),
+      credits,
+      justification: form.justification.trim(),
+      debtCeilingCredits: ceiling
+    };
+
+    if (form.repaymentPlan.trim()) {
+      payload.repaymentPlan = form.repaymentPlan.trim();
+    }
+
+    if (form.repaymentDueAt) {
+      payload.repaymentDueAt = new Date(form.repaymentDueAt).toISOString();
+    }
+
+    setStatus({ state: "submitting" });
+
+    try {
+      const response = await fetch("/api/emergency-overrides", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload)
+      });
+
+      const body = await response.json().catch(() => ({}));
+
+      if (!response.ok) {
+        const message = typeof body.error === "string" ? body.error : "Unable to apply emergency override.";
+        setStatus({ state: "error", message });
+        return;
+      }
+
+      setStatus({
+        state: "success",
+        message:
+          typeof body.caseId === "string"
+            ? `Emergency override logged (case ${body.caseId}).`
+            : "Emergency override applied."
+      });
+
+      setForm((prev) => ({
+        ...prev,
+        credits: "1",
+        justification: "",
+        repaymentPlan: "",
+        repaymentDueAt: ""
+      }));
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unexpected error while applying override.";
+      setStatus({ state: "error", message });
+    }
+  }
+
+  const isSubmitting = status.state === "submitting";
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="grid gap-4 md:grid-cols-2">
+        <div className="space-y-2">
+          <label htmlFor="beneficiaryId" className="text-sm font-medium text-slate-200">
+            Beneficiary ID
+          </label>
+          <input
+            id="beneficiaryId"
+            name="beneficiaryId"
+            value={form.beneficiaryId}
+            onChange={(event) => updateField("beneficiaryId", event.target.value)}
+            required
+            className="w-full rounded-xl border border-white/10 bg-black/30 px-4 py-2 text-sm text-white placeholder-slate-400 focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary/40"
+          />
+        </div>
+        <div className="space-y-2">
+          <label htmlFor="organizationId" className="text-sm font-medium text-slate-200">
+            Organization ID
+          </label>
+          <input
+            id="organizationId"
+            name="organizationId"
+            value={form.organizationId}
+            onChange={(event) => updateField("organizationId", event.target.value)}
+            required
+            className="w-full rounded-xl border border-white/10 bg-black/30 px-4 py-2 text-sm text-white placeholder-slate-400 focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary/40"
+          />
+        </div>
+        <div className="space-y-2">
+          <label htmlFor="initiatedBy" className="text-sm font-medium text-slate-200">
+            Initiated by (admin/government)
+          </label>
+          <input
+            id="initiatedBy"
+            name="initiatedBy"
+            value={form.initiatedBy}
+            onChange={(event) => updateField("initiatedBy", event.target.value)}
+            required
+            className="w-full rounded-xl border border-white/10 bg-black/30 px-4 py-2 text-sm text-white placeholder-slate-400 focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary/40"
+          />
+        </div>
+        <div className="space-y-2">
+          <label htmlFor="credits" className="text-sm font-medium text-slate-200">
+            Override credits
+          </label>
+          <input
+            id="credits"
+            name="credits"
+            type="number"
+            min={1}
+            step={1}
+            value={form.credits}
+            onChange={(event) => updateField("credits", event.target.value)}
+            required
+            className="w-full rounded-xl border border-white/10 bg-black/30 px-4 py-2 text-sm text-white focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary/40"
+          />
+        </div>
+        <div className="space-y-2">
+          <label htmlFor="debtCeilingCredits" className="text-sm font-medium text-slate-200">
+            Debt ceiling credits
+          </label>
+          <input
+            id="debtCeilingCredits"
+            name="debtCeilingCredits"
+            type="number"
+            min={1}
+            step={1}
+            value={form.debtCeilingCredits}
+            onChange={(event) => updateField("debtCeilingCredits", event.target.value)}
+            required
+            className="w-full rounded-xl border border-white/10 bg-black/30 px-4 py-2 text-sm text-white focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary/40"
+          />
+        </div>
+        <div className="space-y-2 md:col-span-2">
+          <label htmlFor="justification" className="text-sm font-medium text-slate-200">
+            Justification
+          </label>
+          <textarea
+            id="justification"
+            name="justification"
+            rows={3}
+            value={form.justification}
+            onChange={(event) => updateField("justification", event.target.value)}
+            required
+            placeholder="Summarize the emergency need and approvals"
+            className="w-full rounded-xl border border-white/10 bg-black/30 px-4 py-2 text-sm text-white placeholder-slate-400 focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary/40"
+          />
+        </div>
+        <div className="space-y-2 md:col-span-2">
+          <label htmlFor="repaymentPlan" className="text-sm font-medium text-slate-200">
+            Repayment plan
+          </label>
+          <textarea
+            id="repaymentPlan"
+            name="repaymentPlan"
+            rows={3}
+            value={form.repaymentPlan}
+            onChange={(event) => updateField("repaymentPlan", event.target.value)}
+            placeholder="Outline how the credits will be replenished"
+            className="w-full rounded-xl border border-white/10 bg-black/30 px-4 py-2 text-sm text-white placeholder-slate-400 focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary/40"
+          />
+        </div>
+        <div className="space-y-2">
+          <label htmlFor="repaymentDueAt" className="text-sm font-medium text-slate-200">
+            Repayment due date
+          </label>
+          <input
+            id="repaymentDueAt"
+            name="repaymentDueAt"
+            type="date"
+            value={form.repaymentDueAt}
+            onChange={(event) => updateField("repaymentDueAt", event.target.value)}
+            className="w-full rounded-xl border border-white/10 bg-black/30 px-4 py-2 text-sm text-white focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary/40"
+          />
+        </div>
+      </div>
+      <div className="flex items-center justify-between gap-4">
+        <button
+          type="submit"
+          disabled={isSubmitting}
+          className="inline-flex items-center justify-center rounded-full bg-brand-primary px-4 py-2 text-sm font-semibold text-white transition hover:bg-brand-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {isSubmitting ? "Posting override…" : "Post override"}
+        </button>
+        <p className="text-xs text-slate-400">
+          Overrides create a temporary negative balance until repayment clears.
+        </p>
+      </div>
+      <div aria-live="polite" className="min-h-[1.5rem] text-sm">
+        {status.state === "success" && status.message ? (
+          <p className="rounded-xl border border-emerald-400/30 bg-emerald-500/10 px-4 py-2 text-emerald-200">
+            {status.message}
+          </p>
+        ) : null}
+        {status.state === "error" && status.message ? (
+          <p className="rounded-xl border border-rose-500/40 bg-rose-500/10 px-4 py-2 text-rose-200">
+            {status.message}
+          </p>
+        ) : null}
+      </div>
+    </form>
+  );
+}

--- a/components/forms/ExchangeProposalForm.tsx
+++ b/components/forms/ExchangeProposalForm.tsx
@@ -1,0 +1,244 @@
+"use client";
+
+import { useState } from "react";
+
+type StatusState = "idle" | "submitting" | "success" | "error";
+
+type FormState = {
+  requestingOrgId: string;
+  offeringOrgId: string;
+  requestedBloodType: string;
+  requestedCredits: string;
+  offeredBloodType: string;
+  offeredCredits: string;
+  notes: string;
+};
+
+interface ExchangeProposalFormProps {
+  defaultOrganizationId: string;
+}
+
+const BLOOD_TYPES = ["A+", "A-", "B+", "B-", "AB+", "AB-", "O+", "O-"];
+
+export function ExchangeProposalForm({ defaultOrganizationId }: ExchangeProposalFormProps) {
+  const [form, setForm] = useState<FormState>({
+    requestingOrgId: defaultOrganizationId,
+    offeringOrgId: "",
+    requestedBloodType: BLOOD_TYPES[0],
+    requestedCredits: "2",
+    offeredBloodType: BLOOD_TYPES[1],
+    offeredCredits: "2",
+    notes: ""
+  });
+  const [status, setStatus] = useState<{ state: StatusState; message?: string }>({ state: "idle" });
+
+  function updateField<K extends keyof FormState>(field: K, value: FormState[K]) {
+    setForm((prev) => ({ ...prev, [field]: value }));
+  }
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    const requestedCredits = Number.parseInt(form.requestedCredits, 10);
+    const offeredCredits = Number.parseInt(form.offeredCredits, 10);
+
+    if (!Number.isInteger(requestedCredits) || requestedCredits <= 0) {
+      setStatus({ state: "error", message: "Requested credits must be a positive integer." });
+      return;
+    }
+
+    if (!Number.isInteger(offeredCredits) || offeredCredits <= 0) {
+      setStatus({ state: "error", message: "Offered credits must be a positive integer." });
+      return;
+    }
+
+    const payload = {
+      requestingOrgId: form.requestingOrgId.trim(),
+      offeringOrgId: form.offeringOrgId.trim(),
+      requested: {
+        bloodType: form.requestedBloodType,
+        credits: requestedCredits
+      },
+      offered: {
+        bloodType: form.offeredBloodType,
+        credits: offeredCredits
+      },
+      ...(form.notes.trim() ? { notes: form.notes.trim() } : {})
+    };
+
+    setStatus({ state: "submitting" });
+
+    try {
+      const response = await fetch("/api/exchanges", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload)
+      });
+
+      const body = await response.json().catch(() => ({}));
+
+      if (!response.ok) {
+        const message = typeof body.error === "string" ? body.error : "Unable to log exchange.";
+        setStatus({ state: "error", message });
+        return;
+      }
+
+      setStatus({
+        state: "success",
+        message:
+          typeof body.exchangeId === "string"
+            ? `Exchange proposal ${body.exchangeId} recorded.`
+            : "Exchange proposal recorded."
+      });
+
+      setForm((prev) => ({
+        ...prev,
+        offeringOrgId: "",
+        offeredCredits: "2",
+        notes: ""
+      }));
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unexpected error while logging exchange.";
+      setStatus({ state: "error", message });
+    }
+  }
+
+  const isSubmitting = status.state === "submitting";
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="grid gap-4 md:grid-cols-2">
+        <div className="space-y-2">
+          <label htmlFor="requestingOrgId" className="text-sm font-medium text-slate-200">
+            Requesting organization ID
+          </label>
+          <input
+            id="requestingOrgId"
+            name="requestingOrgId"
+            value={form.requestingOrgId}
+            onChange={(event) => updateField("requestingOrgId", event.target.value)}
+            required
+            className="w-full rounded-xl border border-white/10 bg-black/30 px-4 py-2 text-sm text-white placeholder-slate-400 focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary/40"
+          />
+        </div>
+        <div className="space-y-2">
+          <label htmlFor="offeringOrgId" className="text-sm font-medium text-slate-200">
+            Partner organization ID
+          </label>
+          <input
+            id="offeringOrgId"
+            name="offeringOrgId"
+            value={form.offeringOrgId}
+            onChange={(event) => updateField("offeringOrgId", event.target.value)}
+            required
+            className="w-full rounded-xl border border-white/10 bg-black/30 px-4 py-2 text-sm text-white placeholder-slate-400 focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary/40"
+          />
+        </div>
+        <div className="space-y-2">
+          <label htmlFor="requestedBloodType" className="text-sm font-medium text-slate-200">
+            Requesting blood type
+          </label>
+          <select
+            id="requestedBloodType"
+            name="requestedBloodType"
+            value={form.requestedBloodType}
+            onChange={(event) => updateField("requestedBloodType", event.target.value)}
+            className="w-full rounded-xl border border-white/10 bg-black/30 px-4 py-2 text-sm text-white focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary/40"
+          >
+            {BLOOD_TYPES.map((type) => (
+              <option key={type} value={type}>
+                {type}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="space-y-2">
+          <label htmlFor="requestedCredits" className="text-sm font-medium text-slate-200">
+            Credits requested
+          </label>
+          <input
+            id="requestedCredits"
+            name="requestedCredits"
+            type="number"
+            min={1}
+            step={1}
+            value={form.requestedCredits}
+            onChange={(event) => updateField("requestedCredits", event.target.value)}
+            required
+            className="w-full rounded-xl border border-white/10 bg-black/30 px-4 py-2 text-sm text-white focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary/40"
+          />
+        </div>
+        <div className="space-y-2">
+          <label htmlFor="offeredBloodType" className="text-sm font-medium text-slate-200">
+            Offered blood type
+          </label>
+          <select
+            id="offeredBloodType"
+            name="offeredBloodType"
+            value={form.offeredBloodType}
+            onChange={(event) => updateField("offeredBloodType", event.target.value)}
+            className="w-full rounded-xl border border-white/10 bg-black/30 px-4 py-2 text-sm text-white focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary/40"
+          >
+            {BLOOD_TYPES.map((type) => (
+              <option key={type} value={type}>
+                {type}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="space-y-2">
+          <label htmlFor="offeredCredits" className="text-sm font-medium text-slate-200">
+            Credits offered
+          </label>
+          <input
+            id="offeredCredits"
+            name="offeredCredits"
+            type="number"
+            min={1}
+            step={1}
+            value={form.offeredCredits}
+            onChange={(event) => updateField("offeredCredits", event.target.value)}
+            required
+            className="w-full rounded-xl border border-white/10 bg-black/30 px-4 py-2 text-sm text-white focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary/40"
+          />
+        </div>
+        <div className="space-y-2 md:col-span-2">
+          <label htmlFor="notes" className="text-sm font-medium text-slate-200">
+            Negotiation notes
+          </label>
+          <textarea
+            id="notes"
+            name="notes"
+            rows={3}
+            value={form.notes}
+            onChange={(event) => updateField("notes", event.target.value)}
+            placeholder="Capture commitments or delivery timelines"
+            className="w-full rounded-xl border border-white/10 bg-black/30 px-4 py-2 text-sm text-white placeholder-slate-400 focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary/40"
+          />
+        </div>
+      </div>
+      <div className="flex items-center justify-between gap-4">
+        <button
+          type="submit"
+          disabled={isSubmitting}
+          className="inline-flex items-center justify-center rounded-full bg-brand-primary px-4 py-2 text-sm font-semibold text-white transition hover:bg-brand-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {isSubmitting ? "Logging exchange…" : "Log exchange"}
+        </button>
+        <p className="text-xs text-slate-400">Ledger differentials flag make-up deliveries automatically.</p>
+      </div>
+      <div aria-live="polite" className="min-h-[1.5rem] text-sm">
+        {status.state === "success" && status.message ? (
+          <p className="rounded-xl border border-emerald-400/30 bg-emerald-500/10 px-4 py-2 text-emerald-200">
+            {status.message}
+          </p>
+        ) : null}
+        {status.state === "error" && status.message ? (
+          <p className="rounded-xl border border-rose-500/40 bg-rose-500/10 px-4 py-2 text-rose-200">
+            {status.message}
+          </p>
+        ) : null}
+      </div>
+    </form>
+  );
+}

--- a/components/forms/RecordDonationForm.tsx
+++ b/components/forms/RecordDonationForm.tsx
@@ -1,0 +1,277 @@
+"use client";
+
+import { useState } from "react";
+
+type StatusState = "idle" | "submitting" | "success" | "error";
+
+type FormState = {
+  donorId: string;
+  organizationId: string;
+  bloodType: string;
+  component: string;
+  credits: string;
+  volumeMl: string;
+  collectedAt: string;
+  notes: string;
+};
+
+interface RecordDonationFormProps {
+  defaultDonorId: string;
+  defaultOrganizationId: string;
+}
+
+const BLOOD_TYPES = ["A+", "A-", "B+", "B-", "AB+", "AB-", "O+", "O-"];
+
+const BLOOD_COMPONENTS: Array<{ value: string; label: string }> = [
+  { value: "whole_blood", label: "Whole blood" },
+  { value: "packed_rbc", label: "Packed RBC" },
+  { value: "plasma", label: "Plasma" },
+  { value: "platelets", label: "Platelets" },
+  { value: "cryoprecipitate", label: "Cryoprecipitate" }
+];
+
+export function RecordDonationForm({ defaultDonorId, defaultOrganizationId }: RecordDonationFormProps) {
+  const [form, setForm] = useState<FormState>({
+    donorId: defaultDonorId,
+    organizationId: defaultOrganizationId,
+    bloodType: BLOOD_TYPES[0],
+    component: BLOOD_COMPONENTS[0].value,
+    credits: "1",
+    volumeMl: "",
+    collectedAt: "",
+    notes: ""
+  });
+  const [status, setStatus] = useState<{ state: StatusState; message?: string }>({ state: "idle" });
+
+  function updateField<K extends keyof FormState>(field: K, value: FormState[K]) {
+    setForm((prev) => ({ ...prev, [field]: value }));
+  }
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const credits = Number.parseInt(form.credits, 10);
+    if (!Number.isInteger(credits) || credits <= 0) {
+      setStatus({ state: "error", message: "Credits must be a positive integer." });
+      return;
+    }
+
+    const volume = form.volumeMl ? Number.parseInt(form.volumeMl, 10) : undefined;
+    if (form.volumeMl && (!Number.isInteger(volume!) || volume! <= 0)) {
+      setStatus({ state: "error", message: "Volume must be a positive integer." });
+      return;
+    }
+
+    const payload: Record<string, unknown> = {
+      donorId: form.donorId.trim(),
+      organizationId: form.organizationId.trim(),
+      bloodType: form.bloodType,
+      component: form.component,
+      credits
+    };
+
+    if (typeof volume === "number") {
+      payload.volumeMl = volume;
+    }
+
+    if (form.collectedAt) {
+      payload.collectedAt = new Date(form.collectedAt).toISOString();
+    }
+
+    if (form.notes.trim()) {
+      payload.notes = form.notes.trim();
+    }
+
+    setStatus({ state: "submitting" });
+
+    try {
+      const response = await fetch("/api/donations", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload)
+      });
+
+      const body = await response.json().catch(() => ({}));
+
+      if (!response.ok) {
+        const message = typeof body.error === "string" ? body.error : "Unable to record donation.";
+        setStatus({ state: "error", message });
+        return;
+      }
+
+      setStatus({
+        state: "success",
+        message:
+          typeof body.transactionId === "string"
+            ? `Donation recorded (transaction ${body.transactionId}).`
+            : "Donation recorded successfully."
+      });
+
+      setForm((prev) => ({
+        ...prev,
+        credits: "1",
+        volumeMl: "",
+        collectedAt: "",
+        notes: ""
+      }));
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unexpected error while recording donation.";
+      setStatus({ state: "error", message });
+    }
+  }
+
+  const isSubmitting = status.state === "submitting";
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="grid gap-4 md:grid-cols-2">
+        <div className="space-y-2">
+          <label htmlFor="donorId" className="text-sm font-medium text-slate-200">
+            Donor ID
+          </label>
+          <input
+            id="donorId"
+            name="donorId"
+            value={form.donorId}
+            onChange={(event) => updateField("donorId", event.target.value)}
+            required
+            autoComplete="off"
+            className="w-full rounded-xl border border-white/10 bg-black/30 px-4 py-2 text-sm text-white placeholder-slate-400 focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary/40"
+          />
+        </div>
+        <div className="space-y-2">
+          <label htmlFor="organizationId" className="text-sm font-medium text-slate-200">
+            Organization ID
+          </label>
+          <input
+            id="organizationId"
+            name="organizationId"
+            value={form.organizationId}
+            onChange={(event) => updateField("organizationId", event.target.value)}
+            required
+            autoComplete="off"
+            className="w-full rounded-xl border border-white/10 bg-black/30 px-4 py-2 text-sm text-white placeholder-slate-400 focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary/40"
+          />
+        </div>
+        <div className="space-y-2">
+          <label htmlFor="bloodType" className="text-sm font-medium text-slate-200">
+            Blood type
+          </label>
+          <select
+            id="bloodType"
+            name="bloodType"
+            value={form.bloodType}
+            onChange={(event) => updateField("bloodType", event.target.value)}
+            className="w-full rounded-xl border border-white/10 bg-black/30 px-4 py-2 text-sm text-white focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary/40"
+          >
+            {BLOOD_TYPES.map((type) => (
+              <option key={type} value={type}>
+                {type}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="space-y-2">
+          <label htmlFor="component" className="text-sm font-medium text-slate-200">
+            Component
+          </label>
+          <select
+            id="component"
+            name="component"
+            value={form.component}
+            onChange={(event) => updateField("component", event.target.value)}
+            className="w-full rounded-xl border border-white/10 bg-black/30 px-4 py-2 text-sm text-white focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary/40"
+          >
+            {BLOOD_COMPONENTS.map((component) => (
+              <option key={component.value} value={component.value}>
+                {component.label}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="space-y-2">
+          <label htmlFor="credits" className="text-sm font-medium text-slate-200">
+            Credits
+          </label>
+          <input
+            id="credits"
+            name="credits"
+            type="number"
+            min={1}
+            step={1}
+            value={form.credits}
+            onChange={(event) => updateField("credits", event.target.value)}
+            required
+            className="w-full rounded-xl border border-white/10 bg-black/30 px-4 py-2 text-sm text-white focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary/40"
+          />
+        </div>
+        <div className="space-y-2">
+          <label htmlFor="volumeMl" className="text-sm font-medium text-slate-200">
+            Volume (ml)
+          </label>
+          <input
+            id="volumeMl"
+            name="volumeMl"
+            type="number"
+            min={100}
+            step={50}
+            value={form.volumeMl}
+            onChange={(event) => updateField("volumeMl", event.target.value)}
+            placeholder="Optional"
+            className="w-full rounded-xl border border-white/10 bg-black/30 px-4 py-2 text-sm text-white focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary/40"
+          />
+        </div>
+        <div className="space-y-2">
+          <label htmlFor="collectedAt" className="text-sm font-medium text-slate-200">
+            Collected at
+          </label>
+          <input
+            id="collectedAt"
+            name="collectedAt"
+            type="datetime-local"
+            value={form.collectedAt}
+            onChange={(event) => updateField("collectedAt", event.target.value)}
+            className="w-full rounded-xl border border-white/10 bg-black/30 px-4 py-2 text-sm text-white focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary/40"
+          />
+        </div>
+        <div className="space-y-2 md:col-span-2">
+          <label htmlFor="notes" className="text-sm font-medium text-slate-200">
+            Notes
+          </label>
+          <textarea
+            id="notes"
+            name="notes"
+            rows={3}
+            value={form.notes}
+            onChange={(event) => updateField("notes", event.target.value)}
+            placeholder="Optional context for audit trail"
+            className="w-full rounded-xl border border-white/10 bg-black/30 px-4 py-2 text-sm text-white placeholder-slate-400 focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary/40"
+          />
+        </div>
+      </div>
+      <div className="flex items-center justify-between gap-4">
+        <button
+          type="submit"
+          disabled={isSubmitting}
+          className="inline-flex items-center justify-center rounded-full bg-brand-primary px-4 py-2 text-sm font-semibold text-white transition hover:bg-brand-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {isSubmitting ? "Recording donation…" : "Record donation"}
+        </button>
+        <p className="text-xs text-slate-400">
+          Donations increment donor credits and organizational inventory in a single transaction.
+        </p>
+      </div>
+      <div aria-live="polite" className="min-h-[1.5rem] text-sm">
+        {status.state === "success" && status.message ? (
+          <p className="rounded-xl border border-emerald-400/30 bg-emerald-500/10 px-4 py-2 text-emerald-200">
+            {status.message}
+          </p>
+        ) : null}
+        {status.state === "error" && status.message ? (
+          <p className="rounded-xl border border-rose-500/40 bg-rose-500/10 px-4 py-2 text-rose-200">
+            {status.message}
+          </p>
+        ) : null}
+      </div>
+    </form>
+  );
+}

--- a/components/forms/RespondConsentForm.tsx
+++ b/components/forms/RespondConsentForm.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import { useState } from "react";
+
+type StatusState = "idle" | "submitting" | "success" | "error";
+
+type FormState = {
+  requestId: string;
+  actorId: string;
+  decision: "approve" | "decline";
+  note: string;
+};
+
+interface RespondConsentFormProps {
+  defaultActorId: string;
+}
+
+export function RespondConsentForm({ defaultActorId }: RespondConsentFormProps) {
+  const [form, setForm] = useState<FormState>({
+    requestId: "",
+    actorId: defaultActorId,
+    decision: "approve",
+    note: ""
+  });
+  const [status, setStatus] = useState<{ state: StatusState; message?: string }>({ state: "idle" });
+
+  function updateField<K extends keyof FormState>(field: K, value: FormState[K]) {
+    setForm((prev) => ({ ...prev, [field]: value }));
+  }
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    if (!form.requestId.trim()) {
+      setStatus({ state: "error", message: "Provide the consent request ID." });
+      return;
+    }
+
+    const payload: Record<string, unknown> = {
+      actorId: form.actorId.trim(),
+      decision: form.decision
+    };
+
+    if (form.note.trim()) {
+      payload.note = form.note.trim();
+    }
+
+    setStatus({ state: "submitting" });
+
+    try {
+      const response = await fetch(`/api/consents/${encodeURIComponent(form.requestId.trim())}/decision`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload)
+      });
+
+      const body = await response.json().catch(() => ({}));
+
+      if (!response.ok) {
+        const message = typeof body.error === "string" ? body.error : "Unable to submit decision.";
+        setStatus({ state: "error", message });
+        return;
+      }
+
+      setStatus({
+        state: "success",
+        message: body.status ? `Request resolved as ${body.status.toLowerCase()}.` : "Decision submitted."
+      });
+
+      setForm((prev) => ({ ...prev, requestId: "", note: "" }));
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unexpected error while submitting decision.";
+      setStatus({ state: "error", message });
+    }
+  }
+
+  const isSubmitting = status.state === "submitting";
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="grid gap-4 md:grid-cols-2">
+        <div className="space-y-2">
+          <label htmlFor="requestId" className="text-sm font-medium text-slate-200">
+            Consent request ID
+          </label>
+          <input
+            id="requestId"
+            name="requestId"
+            value={form.requestId}
+            onChange={(event) => updateField("requestId", event.target.value)}
+            required
+            className="w-full rounded-xl border border-white/10 bg-black/30 px-4 py-2 text-sm text-white placeholder-slate-400 focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary/40"
+          />
+        </div>
+        <div className="space-y-2">
+          <label htmlFor="actorId" className="text-sm font-medium text-slate-200">
+            Decision maker ID
+          </label>
+          <input
+            id="actorId"
+            name="actorId"
+            value={form.actorId}
+            onChange={(event) => updateField("actorId", event.target.value)}
+            required
+            className="w-full rounded-xl border border-white/10 bg-black/30 px-4 py-2 text-sm text-white placeholder-slate-400 focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary/40"
+          />
+        </div>
+        <div className="space-y-2">
+          <span className="text-sm font-medium text-slate-200">Decision</span>
+          <div className="flex items-center gap-4 rounded-2xl border border-white/10 bg-black/30 px-4 py-3 text-sm text-white">
+            <label className="flex items-center gap-2">
+              <input
+                type="radio"
+                name="decision"
+                value="approve"
+                checked={form.decision === "approve"}
+                onChange={() => updateField("decision", "approve")}
+                className="h-4 w-4 border-white/30 bg-black/50 text-brand-primary focus:ring-brand-primary/50"
+              />
+              Approve
+            </label>
+            <label className="flex items-center gap-2">
+              <input
+                type="radio"
+                name="decision"
+                value="decline"
+                checked={form.decision === "decline"}
+                onChange={() => updateField("decision", "decline")}
+                className="h-4 w-4 border-white/30 bg-black/50 text-brand-primary focus:ring-brand-primary/50"
+              />
+              Decline
+            </label>
+          </div>
+        </div>
+        <div className="space-y-2 md:col-span-2">
+          <label htmlFor="note" className="text-sm font-medium text-slate-200">
+            Decision note
+          </label>
+          <textarea
+            id="note"
+            name="note"
+            rows={3}
+            value={form.note}
+            onChange={(event) => updateField("note", event.target.value)}
+            placeholder="Optional context for the audit log"
+            className="w-full rounded-xl border border-white/10 bg-black/30 px-4 py-2 text-sm text-white placeholder-slate-400 focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary/40"
+          />
+        </div>
+      </div>
+      <div className="flex items-center justify-between gap-4">
+        <button
+          type="submit"
+          disabled={isSubmitting}
+          className="inline-flex items-center justify-center rounded-full bg-brand-primary px-4 py-2 text-sm font-semibold text-white transition hover:bg-brand-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {isSubmitting ? "Submitting decision…" : "Submit decision"}
+        </button>
+        <p className="text-xs text-slate-400">Approvals immediately debit credits and notify the organization.</p>
+      </div>
+      <div aria-live="polite" className="min-h-[1.5rem] text-sm">
+        {status.state === "success" && status.message ? (
+          <p className="rounded-xl border border-emerald-400/30 bg-emerald-500/10 px-4 py-2 text-emerald-200">
+            {status.message}
+          </p>
+        ) : null}
+        {status.state === "error" && status.message ? (
+          <p className="rounded-xl border border-rose-500/40 bg-rose-500/10 px-4 py-2 text-rose-200">
+            {status.message}
+          </p>
+        ) : null}
+      </div>
+    </form>
+  );
+}

--- a/components/layout/TopNav.tsx
+++ b/components/layout/TopNav.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { signIn, signOut, useSession } from "next-auth/react";
+import Link from "next/link";
+
+const navLinks: Array<{ href: string; label: string; requireAuth?: boolean }> = [
+  { href: "/", label: "Home" },
+  { href: "/workspace", label: "Workspace", requireAuth: true },
+  { href: "/docs/architecture", label: "Architecture" },
+  { href: "#features", label: "Features" }
+];
+
+export function TopNav() {
+  const { data: session, status } = useSession();
+  const isAuthenticated = status === "authenticated";
+  const primaryRole = session?.user?.roles?.[0];
+
+  return (
+    <header className="fixed inset-x-0 top-0 z-50 border-b border-white/10 bg-slate-950/60 backdrop-blur">
+      <nav className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4 text-sm">
+        <Link href="/" className="flex items-center gap-2 font-semibold tracking-wide text-white">
+          <span className="flex h-8 w-8 items-center justify-center rounded-full bg-brand-primary font-bold">B+</span>
+          <span>B+ive</span>
+        </Link>
+        <ul className="hidden items-center gap-6 text-slate-200 md:flex">
+          {navLinks
+            .filter((link) => (link.requireAuth ? isAuthenticated : true))
+            .map((link) => (
+              <li key={link.href}>
+                <Link className="transition hover:text-brand-accent" href={link.href}>
+                  {link.label}
+                </Link>
+              </li>
+            ))}
+        </ul>
+        <div className="flex items-center gap-3">
+          {isAuthenticated ? (
+            <>
+              <div className="hidden flex-col text-right text-xs font-medium text-slate-300 sm:flex">
+                <span className="text-white">{session?.user?.name ?? session?.user?.email}</span>
+                {primaryRole ? <span className="uppercase tracking-wide text-brand-accent">{primaryRole}</span> : null}
+              </div>
+              <button
+                type="button"
+                onClick={() => signOut({ callbackUrl: "/" })}
+                className="rounded-full border border-white/10 bg-white/5 px-4 py-2 font-semibold text-white transition hover:bg-white/10"
+              >
+                Sign out
+              </button>
+            </>
+          ) : (
+            <button
+              type="button"
+              onClick={() => signIn(undefined, { callbackUrl: "/workspace" })}
+              className="rounded-full border border-white/10 bg-white/5 px-4 py-2 font-semibold text-white transition hover:bg-white/10"
+            >
+              Sign in
+            </button>
+          )}
+        </div>
+      </nav>
+    </header>
+  );
+}

--- a/components/providers/AppProviders.tsx
+++ b/components/providers/AppProviders.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { SessionProvider } from "next-auth/react";
+
+export function AppProviders({ children }: { children: React.ReactNode }) {
+  return <SessionProvider>{children}</SessionProvider>;
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,170 @@
+# B+ive Platform Architecture Overview
+
+## Vision
+B+ive is a blood-credit exchange network that enables donors, recipients, hospitals, and government entities to coordinate blood transfers through a credit-based ledger. Donors earn credits whenever they donate blood through a participating organization, and those credits can later be redeemed by themselves or other authorized users. Administrators and government agencies oversee compliance, verify identities, and manage participating organizations.
+
+## Core Requirements
+- **Role-based access** for administrators, government entities, organizations (hospitals/blood banks), and end users.
+- **Blood credit ledger** that tracks donations and withdrawals at a fine-grained unit level (e.g., 100 ml = 1 credit).
+- **Consent-driven transfers** so that credits can only be used with donor approval, with emergency override workflows for admins/government.
+- **Traceability** for all transactions, linked to verified identity documents and medical history.
+- **Emergency support** so admins/government entities can authorize urgent blood allocations even when no donor is immediately available.
+
+## Recommended Technology Stack
+| Layer | Recommendation | Rationale |
+| --- | --- | --- |
+| Frontend | **Next.js (React)** with TypeScript, Tailwind CSS, and React Query/TanStack Query | Next.js offers server-side rendering, API routes, and seamless deployment on Vercel. TypeScript improves reliability, Tailwind speeds UI development, and React Query simplifies data fetching. |
+| Backend | **NestJS (Node.js + TypeScript)** or **Next.js API routes** for smaller deployments; integrates with REST/GraphQL | NestJS provides modular architecture, dependency injection, and mature authentication/authorization patterns. For a unified full-stack, Next.js API routes can cover early-stage needs. |
+| Database | **MongoDB Atlas** (free tier) | Document model fits user profiles, credit ledgers, and transaction history. Offers serverless/auto-scaling plans and is included in GitHub Student Developer Pack. |
+| Authentication | **NextAuth.js** or **Auth0** (Student plan), integrate Aadhaar/ID verification workflows as custom providers | Provides secure session management and supports role-based access. |
+| Hosting | **Vercel** for the Next.js frontend/backend, **MongoDB Atlas** for data, optional **Render/Fly.io** for standalone NestJS services | Vercel has excellent support for Next.js and generous free tier; Render/Fly.io provide alternatives if background jobs or persistent processes are needed. |
+| Messaging & Notifications | **Twilio SendGrid** (email/SMS) or **Firebase Cloud Messaging** | Supports donor consent prompts, emergency notifications, and status updates. |
+| Infrastructure as Code | **Terraform** or **Pulumi** (later phases) | Enables repeatable environment setup when scaling beyond free tiers. |
+| Monitoring | **Logtail**, **Sentry**, or **Vercel Analytics** | Observability for compliance and auditing.
+
+## High-Level Architecture
+```
++---------------------------+        +---------------------------+
+|      Admin Portal         |        |   Government Portal       |
+|  (Next.js frontend)       |        |  (role-scoped frontend)   |
++-------------+-------------+        +-------------+-------------+
+              |                                   |
+              v                                   v
+        +------------------ API Gateway / Backend Service Layer ------------------+
+        |  Authentication & Authorization (RBAC, OAuth, Aadhaar verification)     |
+        |  Donation & Credit Ledger Service (transactions, balances, audits)      |
+        |  Organization Management Service (enroll, verify, monitor hospitals)    |
+        |  User Profile Service (ID docs, medical history, emergency contacts)    |
+        |  Notification Service (consent requests, alerts, emergency escalations) |
+        +----------------------+---------------------------+----------------------+
+                                   |                       |
+                                   v                       v
+                          +------------------+   +-----------------------+
+                          | MongoDB Atlas    |   | External Integrations |
+                          |  - Users         |   |  - SMS/Email (Twilio) |
+                          |  - Organizations |   |  - Identity APIs      |
+                          |  - Credits       |   |  - Audit Storage      |
+                          |  - Transactions  |   +-----------------------+
+                          +------------------+
+```
+
+## Domain Model Overview
+- **User**: Individual donor/recipient with verified identity, blood group, contact details, consent preferences, credit balance, emergency contacts.
+- **Organization**: Hospital/blood bank with licensing information, service locations, inventory, audit logs, and per-blood-type credit balances for inter-org exchange.
+- **Admin**: Platform superuser responsible for onboarding organizations and government entities, managing policies.
+- **Government Entity**: Regulator with visibility into all transactions, authority to authorize emergency draws and compliance audits.
+- **Credit Transaction**: Records credit earning (donation), debit (withdrawal), transfers, and emergency overrides.
+- **Consent Request**: Pending approval from credit owner authorizing someone else to spend credits.
+- **Emergency Case**: Special workflow triggered by admins/government to allocate blood without prior credit, capturing justification, repayment plan, and enforcement status.
+- **Inventory Item**: Tracks per-organization stock levels (blood type, units, expiry), threshold alerts, and synchronization status with the ledger.
+- **Inter-Organization Exchange**: Represents credit swaps between organizations, capturing requested/offered blood-type pairs, approvals, and reconciliation state.
+
+## Consent Workflow
+1. **Request initiation** – Organization staff select a beneficiary, specify the number of credits (in 100 ml units), and optionally attach clinical context.
+2. **Notification delivery** – The credit owner receives a notification (email, SMS, in-app push) containing beneficiary details, requested amount, organization name, and expiry time.
+3. **Review & decision** – Within the donor portal, the credit owner can approve or decline. Approvals require explicit confirmation plus optional notes; declines capture rationale for audit.
+4. **Ledger update** – Only after approval does the ledger post a debit and emit receipts to the organization and donor. Declines leave the ledger untouched.
+5. **Audit retention** – Consent artifacts (request payload, donor decision, timestamps, notifier delivery status) are stored immutably for future audits. Emergency overrides bypass donor consent but still log the administrator’s justification and repayment plan.
+
+This per-transaction approach prevents blanket or standing approvals while maintaining a complete audit trail.
+
+## Emergency Overrides
+- **Synchronous debit** – Admins or government entities can execute an override that immediately debits credits, allowing the beneficiary balance to go negative.
+- **Configurable ceiling** – A platform-wide policy (adjustable by admins) caps the maximum negative balance, defined in credits (100 ml units). Only one outstanding negative balance per beneficiary is allowed; the balance must return to ≥0 before another override is granted.
+- **Repayment tracking** – Overrides store justification, repayment plan, repayment status, and follow-up timestamps. Progress updates transition the case from “Outstanding” to “Settled”.
+- **UI indicators** – Portals display credit ≥0 in green and <0 in red, with banners summarizing outstanding debt and repayment commitments.
+- **Notifications & audits** – Beneficiaries receive notifications about the debt and upcoming deadlines. All override actions are written to the audit log with actor identity, policy references, and supporting documents.
+
+## Organizational Inventory Management
+- **Stock capture** – Organizations maintain per-blood-type inventory records, including units, component (whole blood, plasma, etc.), collection date, expiry, and storage location.
+- **Alerting** – Thresholds trigger alerts for low stock, impending expirations, or storage anomalies. Notifications route to organization staff and, if severe, administrators.
+- **Synchronization with ledger** – Recording a donation increments both the ledger (crediting the donor) and the organization’s inventory. Fulfillment events decrement inventory while debiting the applicable donor’s credits. Background reconciliation jobs highlight mismatches for review.
+- **Reporting** – Dashboards visualize trends, wastage, and forecasted demand to support inter-organization collaboration.
+
+## Inter-Organization Credit Exchanges
+- **Paired negotiation** – Organizations can negotiate exchanges using `(bloodType, credit)` pairs. Each proposal records what blood type and credit quantity is requested and what is offered in return.
+- **Balancing uneven trades** – If pairs differ (e.g., A+ 2 credits for B 3 credits), the ledger tracks differential balances and can enforce make-up deliveries or administrative settlement.
+- **Approval & audit** – Exchanges require approval from both organizations’ authorized representatives and, optionally, an overseeing admin/government reviewer. All steps, including negotiation messages and final sign-off, are logged.
+- **Ledger impact** – Upon mutual approval, organizational ledgers update to reflect the new per-type credit holdings, while end-user credits remain untouched. Inventory transfers can be linked to exchanges to confirm physical stock movement.
+
+
+## Use Case Diagram (PlantUML)
+```plantuml
+@startuml
+left to right direction
+actor Admin
+actor "Government Entity" as Gov
+actor "Organization" as Org
+actor "User" as User
+
+rectangle "B+ive Platform" {
+  usecase "Manage platform roles" as UC1
+  usecase "Enroll organization" as UC2
+  usecase "Verify donor identity" as UC3
+  usecase "Record blood donation" as UC4
+  usecase "Approve credit redemption" as UC5
+  usecase "Request blood using credits" as UC6
+  usecase "Handle emergency request" as UC7
+  usecase "Audit transaction history" as UC8
+  usecase "View personal donation history" as UC9
+  usecase "Manage blood inventory" as UC10
+  }
+
+Admin --> UC1
+Admin --> UC2
+Admin --> UC7
+Admin --> UC8
+
+Gov --> UC2
+Gov --> UC3
+Gov --> UC7
+Gov --> UC8
+
+Org --> UC3
+Org --> UC4
+Org --> UC5
+Org --> UC6
+Org --> UC10
+
+User --> UC5
+User --> UC6
+User --> UC8
+User --> UC9
+@enduml
+```
+
+The diagram highlights that only organizations record donations and manage inventory, whereas end users focus on redeeming credits, reviewing history, and granting consent. The new “Manage blood inventory” use case reinforces operational responsibilities, and “View personal donation history” surfaces transparency without compromising data integrity.
+
+## Component Responsibilities
+- **Frontend Applications**: Distinct dashboards tailored to each role via RBAC. The public landing page features a 3D animated blood droplet (Three.js or Lottie animation) reinforcing the brand.
+- **API Layer**: Validates requests, enforces consent, and orchestrates workflows. Uses JWT or session tokens with role/permission claims.
+- **Ledger Service**: Ensures credits cannot be double-spent; exposes transactional endpoints to increment/decrement balances with audit trails, including negative-balance policies.
+- **Inventory Service**: Manages stock entries, threshold alerts, and reconciliation jobs that cross-check ledger transactions.
+- **Inter-Organization Exchange Service**: Facilitates negotiation, approval, and settlement of `(bloodType, credit)` swaps while preserving auditability.
+- **Notification Service**: Sends OTPs, consent prompts, emergency alerts, debt reminders, and exchange updates through email/SMS/push notifications.
+- **Analytics & Reporting**: Aggregates data for government oversight (donation trends, organization performance, compliance metrics).
+
+## Development Roadmap
+1. **Phase 1 – Discovery & Prototyping (current)**
+   - Finalize requirements, user journeys, data model, and policy parameters (negative balance ceilings, consent SLA, exchange rules).
+   - Build low-fidelity wireframes and validate with stakeholders.
+   - Implement core authentication and role management in a proof-of-concept environment.
+   - Exit criteria: architecture sign-off, consent/emergency policies approved, inventory schema agreed.
+2. **Phase 2 – MVP**
+   - Implement donation recording, credit ledger, per-transaction consent workflow, and basic dashboards for all roles.
+   - Launch organizational inventory management and simple inter-organization exchange logging.
+   - Integrate MongoDB Atlas and deploy initial version on Vercel (Next.js) or Render (NestJS API).
+3. **Phase 3 – Compliance & Scaling**
+   - Add audit logging, government reporting dashboards, emergency override enforcement tooling.
+   - Integrate identity verification services, debt repayment tracking, and implement encryption at rest/in transit.
+   - Automate reconciliation between ledger and inventory, and expand exchange settlement tooling.
+4. **Phase 4 – Enhancements**
+   - Introduce analytics, notification automation, and mobile-friendly PWA features.
+   - Optimize performance, add caching (Redis), and consider microservice extraction if necessary.
+   - Explore advanced collaboration features (marketplace-style exchange matching, predictive inventory analytics).
+
+## Future-Proofing Considerations
+- Design services with clean interfaces to allow migration to microservices or serverless functions as traffic grows.
+- Store business rules in configurable policies so regulations can be updated without code changes.
+- Maintain comprehensive documentation and automated testing (unit, integration, end-to-end) to facilitate long-term maintenance.
+- Adopt CI/CD pipelines (GitHub Actions) early to enforce quality gates and streamline deployments.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,10 @@
+import nextPlugin from "eslint-config-next";
+
+export default [
+  ...nextPlugin(),
+  {
+    rules: {
+      "@next/next/no-html-link-for-pages": "off"
+    }
+  }
+];

--- a/lib/api/responses.ts
+++ b/lib/api/responses.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server";
+
+import { DomainError } from "@/lib/domain/errors";
+
+export function jsonResponse<T>(data: T, init?: ResponseInit) {
+  return NextResponse.json(data, init);
+}
+
+export function handleApiError(error: unknown) {
+  if (error instanceof DomainError) {
+    return NextResponse.json(
+      {
+        error: error.message,
+        code: error.code
+      },
+      { status: error.status }
+    );
+  }
+
+  console.error("Unhandled API error", error);
+  return NextResponse.json(
+    {
+      error: "Internal server error"
+    },
+    { status: 500 }
+  );
+}

--- a/lib/auth/api.ts
+++ b/lib/auth/api.ts
@@ -1,0 +1,24 @@
+import { getServerSession } from "next-auth";
+
+import { UnauthorizedError } from "@/lib/domain/errors";
+import { authOptions } from "./options";
+
+export async function requireApiSession() {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    throw new UnauthorizedError();
+  }
+
+  return session;
+}
+
+export async function requireApiRole(allowedRoles: string[]) {
+  const session = await requireApiSession();
+  const roles = session.user?.roles ?? [];
+
+  if (!allowedRoles.some((role) => roles.includes(role))) {
+    throw new UnauthorizedError("You are not permitted to perform this action");
+  }
+
+  return session;
+}

--- a/lib/auth/options.ts
+++ b/lib/auth/options.ts
@@ -1,0 +1,75 @@
+import type { NextAuthOptions } from "next-auth";
+import CredentialsProvider from "next-auth/providers/credentials";
+import bcrypt from "bcryptjs";
+
+import { getDatabase } from "@/lib/db/mongodb";
+
+export const authOptions: NextAuthOptions = {
+  session: {
+    strategy: "jwt"
+  },
+  pages: {
+    signIn: "/auth/login"
+  },
+  providers: [
+    CredentialsProvider({
+      name: "Email and password",
+      credentials: {
+        email: { label: "Email", type: "email" },
+        password: { label: "Password", type: "password" }
+      },
+      async authorize(credentials) {
+        if (!credentials?.email || !credentials.password) {
+          return null;
+        }
+
+        const db = await getDatabase();
+        const user = await db.collection("users").findOne({ "auth.email": credentials.email });
+
+        if (!user || !user.auth?.passwordHash) {
+          return null;
+        }
+
+        const passwordValid = await bcrypt.compare(credentials.password, user.auth.passwordHash);
+        if (!passwordValid) {
+          return null;
+        }
+
+        const roles: string[] = Array.isArray(user.roles) ? user.roles : [];
+        const organizationId = typeof user.organizationId === "string" ? user.organizationId : undefined;
+
+        return {
+          id: user.userId ?? user._id?.toString() ?? credentials.email,
+          email: user.auth.email,
+          name: user.name ?? user.userId ?? credentials.email,
+          roles,
+          organizationId
+        } as any;
+      }
+    })
+  ],
+  callbacks: {
+    async jwt({ token, user }) {
+      if (user) {
+        token.sub = user.id;
+        token.email = user.email;
+        token.name = user.name;
+        token.roles = (user as any).roles ?? [];
+        token.organizationId = (user as any).organizationId;
+      }
+
+      return token;
+    },
+    async session({ session, token }) {
+      if (session.user) {
+        session.user.id = token.sub as string;
+        session.user.roles = Array.isArray(token.roles) ? (token.roles as string[]) : [];
+        if (token.organizationId) {
+          session.user.organizationId = token.organizationId as string;
+        }
+      }
+
+      return session;
+    }
+  }
+};

--- a/lib/auth/session.ts
+++ b/lib/auth/session.ts
@@ -1,0 +1,28 @@
+import { redirect } from "next/navigation";
+import { getServerSession } from "next-auth";
+
+import { authOptions } from "@/lib/auth/options";
+
+export async function getCurrentSession() {
+  return getServerSession(authOptions);
+}
+
+export async function requireSession(redirectTo: string) {
+  const session = await getCurrentSession();
+  if (!session) {
+    redirect(`/auth/login?callbackUrl=${encodeURIComponent(redirectTo)}`);
+  }
+
+  return session;
+}
+
+export async function requireRole(allowedRoles: string[], redirectTo: string) {
+  const session = await requireSession(redirectTo);
+  const userRoles = session.user?.roles ?? [];
+
+  if (!allowedRoles.some((role) => userRoles.includes(role))) {
+    redirect("/workspace");
+  }
+
+  return session;
+}

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,0 +1,16 @@
+export const config = {
+  mongodbUri: process.env.MONGODB_URI || "",
+  mongodbDbName: process.env.MONGODB_DB_NAME || "bive",
+  demo: {
+    donorId: process.env.DEMO_DONOR_ID || "user-donor-001",
+    organizationId: process.env.DEMO_ORGANIZATION_ID || "org-sunrise"
+  }
+};
+
+export function assertConfig() {
+  if (!config.mongodbUri) {
+    throw new Error(
+      "Missing MONGODB_URI. Please set it in .env.local based on the provided cluster connection string."
+    );
+  }
+}

--- a/lib/dashboard/constants.ts
+++ b/lib/dashboard/constants.ts
@@ -1,0 +1,30 @@
+export const workspaceHighlights = [
+  {
+    role: "Admin oversight",
+    summary: "Monitor enrollment, compliance tasks, and emergency cases in a single view.",
+    href: "/workspace/admin",
+    cta: "View admin dashboard",
+    roles: ["admin", "government"]
+  },
+  {
+    role: "Government observatory",
+    summary: "Track nationwide coverage, risk hot-spots, and inter-organization exchanges.",
+    href: "/workspace/government",
+    cta: "View government dashboard",
+    roles: ["government", "admin"]
+  },
+  {
+    role: "Organization operations",
+    summary: "Track inventory, fulfill consented withdrawals, and balance inter-organization exchanges.",
+    href: "/workspace/organization",
+    cta: "View organization dashboard",
+    roles: ["organization", "admin"]
+  },
+  {
+    role: "Donor portal",
+    summary: "See credit balances, approve requests, and follow emergency repayments.",
+    href: "/workspace/donor",
+    cta: "View donor dashboard",
+    roles: ["donor", "recipient", "admin"]
+  }
+];

--- a/lib/dashboard/queries.ts
+++ b/lib/dashboard/queries.ts
@@ -1,0 +1,845 @@
+import { randomUUID } from "crypto";
+
+import { getDatabase } from "@/lib/db/mongodb";
+import { getLedgerSummary } from "@/lib/domain/services";
+
+import type {
+  AdminDashboardSnapshot,
+  DonorDashboardSnapshot,
+  GovernmentDashboardSnapshot,
+  InventoryOverviewRow,
+  InventoryRow,
+  Metric,
+  OrganizationDashboardSnapshot,
+  RiskItem,
+  TaskItem,
+  TimelineItem
+} from "./types";
+
+const dateTimeFormatter = new Intl.DateTimeFormat("en-IN", {
+  dateStyle: "medium",
+  timeStyle: "short"
+});
+
+const DAY_IN_MS = 86_400_000;
+const HOUR_IN_MS = 3_600_000;
+const MINUTE_IN_MS = 60_000;
+
+function safeDate(value: unknown): Date | undefined {
+  if (value instanceof Date) {
+    return value;
+  }
+
+  if (typeof value === "string" || typeof value === "number") {
+    const asDate = new Date(value);
+    if (!Number.isNaN(asDate.getTime())) {
+      return asDate;
+    }
+  }
+
+  return undefined;
+}
+
+function formatRelativeOrAbsolute(date: Date | undefined) {
+  if (!date) {
+    return "Unknown";
+  }
+
+  const diff = Date.now() - date.getTime();
+  const abs = Math.abs(diff);
+
+  if (abs < MINUTE_IN_MS) {
+    return diff >= 0 ? "Just now" : "In under a minute";
+  }
+
+  if (abs < HOUR_IN_MS) {
+    const value = Math.round(abs / MINUTE_IN_MS);
+    const unit = value === 1 ? "minute" : "minutes";
+    return diff >= 0 ? `${value} ${unit} ago` : `in ${value} ${unit}`;
+  }
+
+  if (abs < DAY_IN_MS) {
+    const value = Math.round(abs / HOUR_IN_MS);
+    const unit = value === 1 ? "hour" : "hours";
+    return diff >= 0 ? `${value} ${unit} ago` : `in ${value} ${unit}`;
+  }
+
+  if (abs < 7 * DAY_IN_MS) {
+    const value = Math.round(abs / DAY_IN_MS);
+    const unit = value === 1 ? "day" : "days";
+    return diff >= 0 ? `${value} ${unit} ago` : `in ${value} ${unit}`;
+  }
+
+  return dateTimeFormatter.format(date);
+}
+
+function buildTimelineItem(partial: Omit<TimelineItem, "at"> & { at?: string; sortKey?: number }): TimelineItem & { sortKey: number } {
+  const sortKey = partial.sortKey ?? Date.now();
+  return {
+    id: partial.id,
+    title: partial.title,
+    description: partial.description,
+    status: partial.status,
+    at: partial.at ?? "Unknown",
+    sortKey
+  };
+}
+
+function buildMetric(partial: Metric): Metric {
+  return {
+    label: partial.label,
+    value: partial.value,
+    change: partial.change,
+    tone: partial.tone ?? "neutral"
+  };
+}
+
+function buildTask(partial: TaskItem): TaskItem {
+  return {
+    id: partial.id,
+    title: partial.title,
+    detail: partial.detail,
+    at: partial.at
+  };
+}
+
+export async function getAdminDashboardSnapshot(): Promise<AdminDashboardSnapshot> {
+  try {
+    const db = await getDatabase();
+
+    const organizations = db.collection("organizations");
+    const consentRequests = db.collection("consentRequests");
+    const transactions = db.collection("transactions");
+    const emergencyCases = db.collection("emergencyCases");
+
+    const startOfDay = new Date();
+    startOfDay.setHours(0, 0, 0, 0);
+
+    const [
+      activeOrganizations,
+      pendingOrganizations,
+      outstandingEmergency,
+      consentsToday,
+      pendingConsentsToday
+    ] = await Promise.all([
+      organizations.countDocuments({ status: "active" }),
+      organizations.countDocuments({ status: "pending" }),
+      emergencyCases.countDocuments({ status: "OUTSTANDING" }),
+      consentRequests.countDocuments({ requestedAt: { $gte: startOfDay } }),
+      consentRequests.countDocuments({ status: "PENDING", requestedAt: { $gte: startOfDay } })
+    ]);
+
+    const [recentTransactions, recentConsents] = await Promise.all([
+      transactions
+        .find({}, { projection: { _id: 1, type: 1, credits: 1, organizationId: 1, donorId: 1, beneficiaryId: 1, recordedAt: 1 } })
+        .sort({ recordedAt: -1 })
+        .limit(6)
+        .toArray(),
+      consentRequests
+        .find({}, { projection: { _id: 1, status: 1, credits: 1, organizationId: 1, beneficiaryId: 1, decidedAt: 1, requestedAt: 1 } })
+        .sort({ decidedAt: -1, requestedAt: -1 })
+        .limit(4)
+        .toArray()
+    ]);
+
+    const timeline = [
+      ...recentTransactions.map((txn) => {
+        const recordedAt = safeDate(txn.recordedAt);
+        const at = formatRelativeOrAbsolute(recordedAt);
+        let title = "Ledger activity";
+        let description = `${txn.credits} credits processed by ${txn.organizationId}`;
+        let status: TimelineItem["status"] = "info";
+
+        if (txn.type === "DONATION") {
+          title = "Donation recorded";
+          description = `${txn.credits} credits donated by ${txn.donorId ?? "unknown donor"}`;
+          status = "success";
+        } else if (txn.type === "REDEMPTION") {
+          title = "Consent redeemed";
+          description = `${txn.credits} credits fulfilled for ${txn.beneficiaryId ?? "beneficiary"}`;
+          status = "info";
+        } else if (txn.type === "EMERGENCY_OVERRIDE") {
+          title = "Emergency override";
+          description = `${txn.credits} credits allocated to ${txn.beneficiaryId ?? "beneficiary"}`;
+          status = "warning";
+        }
+
+        return buildTimelineItem({
+          id: txn._id?.toString() ?? randomUUID(),
+          title,
+          description,
+          status,
+          at,
+          sortKey: recordedAt?.getTime()
+        });
+      }),
+      ...recentConsents.map((request) => {
+        const decidedAt = safeDate(request.decidedAt) ?? safeDate(request.requestedAt);
+        const at = formatRelativeOrAbsolute(decidedAt);
+        let title = "Consent request";
+        let status: TimelineItem["status"] = "warning";
+
+        if (request.status === "APPROVED") {
+          title = "Consent approved";
+          status = "success";
+        } else if (request.status === "DECLINED") {
+          title = "Consent declined";
+          status = "error";
+        }
+
+        return buildTimelineItem({
+          id: request._id?.toString() ?? randomUUID(),
+          title,
+          description: `${request.credits} credits for ${request.beneficiaryId ?? "beneficiary"} via ${request.organizationId}`,
+          status,
+          at,
+          sortKey: decidedAt?.getTime()
+        });
+      })
+    ]
+      .sort((a, b) => (b.sortKey ?? 0) - (a.sortKey ?? 0))
+      .slice(0, 6)
+      .map(({ sortKey, ...item }) => item);
+
+    const metrics: Metric[] = [
+      buildMetric({
+        label: "Active organizations",
+        value: `${activeOrganizations}`,
+        change:
+          pendingOrganizations > 0
+            ? `${pendingOrganizations} awaiting verification`
+            : "All partners verified",
+        tone: pendingOrganizations > 0 ? "warning" : "positive"
+      }),
+      buildMetric({
+        label: "Outstanding emergency overrides",
+        value: `${outstandingEmergency}`,
+        change:
+          outstandingEmergency > 0
+            ? "Follow repayment plans"
+            : "No emergency debt",
+        tone: outstandingEmergency > 0 ? "warning" : "positive"
+      }),
+      buildMetric({
+        label: "Consent requests today",
+        value: `${consentsToday}`,
+        change:
+          pendingConsentsToday > 0
+            ? `${pendingConsentsToday} awaiting donor approval`
+            : "All requests resolved",
+        tone: pendingConsentsToday > 0 ? "warning" : "neutral"
+      })
+    ];
+
+    const tasks: TaskItem[] = [];
+
+    if (pendingOrganizations > 0) {
+      tasks.push(
+        buildTask({
+          id: "task-pending-orgs",
+          title: `Verify ${pendingOrganizations} pending organization${pendingOrganizations === 1 ? "" : "s"}`,
+          detail: "Complete onboarding checks within the SLA."
+        })
+      );
+    }
+
+    if (outstandingEmergency > 0) {
+      tasks.push(
+        buildTask({
+          id: "task-emergency-repayment",
+          title: `Follow up on ${outstandingEmergency} emergency case${outstandingEmergency === 1 ? "" : "s"}`,
+          detail: "Confirm repayment receipts or extend the repayment plan."
+        })
+      );
+    }
+
+    if (pendingConsentsToday > 0) {
+      tasks.push(
+        buildTask({
+          id: "task-consent-followup",
+          title: `Nudge donors on ${pendingConsentsToday} pending consent${pendingConsentsToday === 1 ? "" : "s"}`,
+          detail: "Escalate urgent requests approaching expiry."
+        })
+      );
+    }
+
+    if (tasks.length === 0) {
+      tasks.push(
+        buildTask({
+          id: "task-clear",
+          title: "All critical queues are clear",
+          detail: "Monitor dashboards for new activity."
+        })
+      );
+    }
+
+    return { metrics, timeline, tasks };
+  } catch (error) {
+    console.error("Failed to build admin dashboard snapshot", error);
+    return { metrics: [], timeline: [], tasks: [] };
+  }
+}
+
+export async function getGovernmentDashboardSnapshot(): Promise<GovernmentDashboardSnapshot> {
+  try {
+    const db = await getDatabase();
+
+    const organizations = db.collection("organizations");
+    const users = db.collection("users");
+    const transactions = db.collection("transactions");
+    const emergencyCases = db.collection("emergencyCases");
+    const exchanges = db.collection("exchanges");
+    const inventoryCollection = db.collection("inventory");
+
+    const startOfDay = new Date();
+    startOfDay.setHours(0, 0, 0, 0);
+
+    const [
+      totalOrganizations,
+      activeOrganizations,
+      pendingOrganizations,
+      registeredDonors,
+      outstandingEmergencies,
+      pendingExchanges,
+      donationsToday,
+      redemptionsToday
+    ] = await Promise.all([
+      organizations.countDocuments({}),
+      organizations.countDocuments({ status: "active" }),
+      organizations.countDocuments({ status: "pending" }),
+      users.countDocuments({ roles: "donor" }),
+      emergencyCases.countDocuments({ status: "OUTSTANDING" }),
+      exchanges.countDocuments({ status: "PENDING" }),
+      transactions.countDocuments({ type: "DONATION", recordedAt: { $gte: startOfDay } }),
+      transactions.countDocuments({ type: "REDEMPTION", recordedAt: { $gte: startOfDay } })
+    ]);
+
+    const inventoryDocs = await inventoryCollection
+      .aggregate([
+        {
+          $group: {
+            _id: "$bloodType",
+            totalCredits: { $sum: { $ifNull: ["$availableCredits", 0] } },
+            organizations: { $addToSet: "$organizationId" }
+          }
+        },
+        { $sort: { _id: 1 } }
+      ])
+      .toArray();
+
+    const [recentEmergencies, recentExchanges, recentOrgEvents] = await Promise.all([
+      emergencyCases.find({}).sort({ updatedAt: -1, createdAt: -1 }).limit(4).toArray(),
+      exchanges.find({}).sort({ proposedAt: -1 }).limit(4).toArray(),
+      organizations.find({}).sort({ verifiedAt: -1, submittedAt: -1 }).limit(4).toArray()
+    ]);
+
+    const inventory: InventoryOverviewRow[] = inventoryDocs.map((doc) => {
+      const totalCredits = typeof doc.totalCredits === "number" ? doc.totalCredits : 0;
+      const organizationCount = Array.isArray(doc.organizations) ? doc.organizations.length : 0;
+      const lowStock = totalCredits < 10;
+
+      return {
+        bloodType: doc._id ?? "Unknown",
+        totalCredits,
+        organizations: organizationCount,
+        lowStock
+      };
+    });
+
+    const metrics: Metric[] = [
+      buildMetric({
+        label: "Verified organizations",
+        value: `${activeOrganizations}`,
+        change:
+          pendingOrganizations > 0
+            ? `${pendingOrganizations} awaiting verification`
+            : `${totalOrganizations} total enrolled`,
+        tone: pendingOrganizations > 0 ? "warning" : "positive"
+      }),
+      buildMetric({
+        label: "Registered donors",
+        value: `${registeredDonors}`,
+        change:
+          donationsToday + redemptionsToday > 0
+            ? `${donationsToday} donations · ${redemptionsToday} redemptions today`
+            : "No ledger movement today",
+        tone: registeredDonors > 0 ? "positive" : "neutral"
+      }),
+      buildMetric({
+        label: "Emergency overrides open",
+        value: `${outstandingEmergencies}`,
+        change:
+          outstandingEmergencies > 0
+            ? "Monitor repayment and follow-up"
+            : "All emergency debt settled",
+        tone: outstandingEmergencies > 0 ? "warning" : "positive"
+      }),
+      buildMetric({
+        label: "Pending exchanges",
+        value: `${pendingExchanges}`,
+        change: pendingExchanges > 0 ? "Coordinate balancing deliveries" : "No pending swaps",
+        tone: pendingExchanges > 0 ? "warning" : "neutral"
+      })
+    ];
+
+    const timeline = [
+      ...recentEmergencies.map((event) => {
+        const updatedAt = safeDate(event.updatedAt) ?? safeDate(event.createdAt);
+        const at = formatRelativeOrAbsolute(updatedAt);
+        const status: TimelineItem["status"] = event.status === "OUTSTANDING" ? "warning" : "success";
+        const title = event.status === "OUTSTANDING" ? "Emergency override active" : "Emergency resolved";
+        const description = `${event.beneficiaryId ?? "beneficiary"} · ${event.credits ?? 0} credits via ${
+          event.organizationId ?? "organization"
+        }`;
+
+        return buildTimelineItem({
+          id: event._id?.toString() ?? randomUUID(),
+          title,
+          description,
+          status,
+          at,
+          sortKey: updatedAt?.getTime()
+        });
+      }),
+      ...recentExchanges.map((exchange) => {
+        const proposedAt = safeDate(exchange.completedAt) ?? safeDate(exchange.proposedAt);
+        const at = formatRelativeOrAbsolute(proposedAt);
+        const status: TimelineItem["status"] = exchange.status === "COMPLETED" ? "success" : "info";
+        const title = exchange.status === "COMPLETED" ? "Exchange completed" : "Exchange proposed";
+        const description = `${exchange.requestingOrgId} ↔ ${exchange.offeringOrgId} (${exchange.requested?.bloodType ?? "?"}/${
+          exchange.offered?.bloodType ?? "?"
+        })`;
+
+        return buildTimelineItem({
+          id: exchange._id?.toString() ?? randomUUID(),
+          title,
+          description,
+          status,
+          at,
+          sortKey: proposedAt?.getTime()
+        });
+      }),
+      ...recentOrgEvents.map((org) => {
+        const status = typeof org.status === "string" ? org.status : "unknown";
+        const referenceDate = safeDate(org.verifiedAt) ?? safeDate(org.submittedAt);
+        const at = formatRelativeOrAbsolute(referenceDate);
+        const isPending = status === "pending";
+
+        return buildTimelineItem({
+          id: org.organizationId ?? randomUUID(),
+          title: isPending ? "Organization awaiting approval" : "Organization verified",
+          description: `${org.name ?? org.organizationId ?? "Organization"} · ${status}`,
+          status: isPending ? "warning" : "success",
+          at,
+          sortKey: referenceDate?.getTime()
+        });
+      })
+    ]
+      .sort((a, b) => (b.sortKey ?? 0) - (a.sortKey ?? 0))
+      .slice(0, 8)
+      .map(({ sortKey, ...item }) => item);
+
+    const risks: RiskItem[] = [];
+
+    if (outstandingEmergencies > 0) {
+      risks.push({
+        id: "risk-emergency",
+        title: "Outstanding emergency overrides",
+        detail: `${outstandingEmergencies} cases require repayment tracking`,
+        severity: "high"
+      });
+    }
+
+    if (pendingOrganizations > 0) {
+      risks.push({
+        id: "risk-pending-orgs",
+        title: "Organizations awaiting verification",
+        detail: `${pendingOrganizations} onboarding checks still open`,
+        severity: "medium"
+      });
+    }
+
+    if (pendingExchanges > 0) {
+      risks.push({
+        id: "risk-pending-exchanges",
+        title: "Credit exchanges awaiting action",
+        detail: `${pendingExchanges} proposals pending counterpart review`,
+        severity: "medium"
+      });
+    }
+
+    inventory.forEach((row) => {
+      if (row.lowStock) {
+        risks.push({
+          id: `risk-low-${row.bloodType}`,
+          title: `${row.bloodType} credits running low`,
+          detail: `${row.totalCredits} credits across ${row.organizations} org${row.organizations === 1 ? "" : "s"}`,
+          severity: row.totalCredits <= 5 ? "high" : "medium"
+        });
+      }
+    });
+
+    if (risks.length === 0) {
+      risks.push({
+        id: "risk-all-clear",
+        title: "No outstanding risks",
+        detail: "All monitored indicators are within expected thresholds",
+        severity: "low"
+      });
+    }
+
+    return { metrics, timeline, risks, inventory };
+  } catch (error) {
+    console.error("Failed to build government dashboard snapshot", error);
+    return { metrics: [], timeline: [], risks: [], inventory: [] };
+  }
+}
+
+export async function getOrganizationDashboardSnapshot(
+  organizationId: string
+): Promise<OrganizationDashboardSnapshot> {
+  try {
+    const db = await getDatabase();
+
+    const organizations = db.collection("organizations");
+    const consentRequests = db.collection("consentRequests");
+    const transactions = db.collection("transactions");
+    const exchanges = db.collection("exchanges");
+    const inventoryCollection = db.collection("inventory");
+
+    const organization = await organizations.findOne({ organizationId });
+
+    const [inventoryDocs, approvedCount, totalRequests, pendingRequests, openExchanges, recentConsents, exchangeEvents] =
+      await Promise.all([
+        inventoryCollection
+          .find({ organizationId })
+          .project({
+            _id: 1,
+            organizationId: 1,
+            bloodType: 1,
+            availableCredits: 1,
+            availableUnits: 1,
+            nextExpiryAt: 1,
+            movements: { $slice: -3 }
+          })
+          .toArray(),
+        consentRequests.countDocuments({ organizationId, status: "APPROVED" }),
+        consentRequests.countDocuments({ organizationId }),
+        consentRequests.countDocuments({ organizationId, status: "PENDING" }),
+        exchanges.countDocuments({
+          status: "PENDING",
+          $or: [{ requestingOrgId: organizationId }, { offeringOrgId: organizationId }]
+        }),
+        consentRequests
+          .find({ organizationId })
+          .sort({ decidedAt: -1, requestedAt: -1 })
+          .limit(4)
+          .toArray(),
+        exchanges
+          .find({
+            $or: [{ requestingOrgId: organizationId }, { offeringOrgId: organizationId }]
+          })
+          .sort({ proposedAt: -1 })
+          .limit(3)
+          .toArray()
+      ]);
+
+    const totalCredits = inventoryDocs.reduce((sum, item) => sum + (item.availableCredits ?? 0), 0);
+    const fulfillmentRate = totalRequests > 0 ? Math.round((approvedCount / totalRequests) * 100) : 100;
+
+    const metrics: Metric[] = [
+      buildMetric({
+        label: "Credits available",
+        value: `${totalCredits} credits`,
+        change: `${inventoryDocs.length} blood type${inventoryDocs.length === 1 ? "" : "s"} tracked`,
+        tone: totalCredits > 0 ? "positive" : "warning"
+      }),
+      buildMetric({
+        label: "Fulfillment SLA",
+        value: `${fulfillmentRate}%`,
+        change:
+          totalRequests > 0
+            ? `${pendingRequests} request${pendingRequests === 1 ? "" : "s"} awaiting donor consent`
+            : "No requests yet",
+        tone: fulfillmentRate >= 90 ? "positive" : "warning"
+      }),
+      buildMetric({
+        label: "Open exchanges",
+        value: `${openExchanges}`,
+        change: openExchanges > 0 ? "Coordinate with partner orgs" : "All exchanges settled",
+        tone: openExchanges > 0 ? "warning" : "neutral"
+      })
+    ];
+
+    const inventory: InventoryRow[] = inventoryDocs.map((doc) => {
+      const nextExpiry = safeDate(doc.nextExpiryAt);
+      const expiresSoon = nextExpiry ? nextExpiry.getTime() - Date.now() < 3 * DAY_IN_MS : false;
+      const units = typeof doc.availableUnits === "number" ? doc.availableUnits : doc.availableCredits ?? 0;
+
+      return {
+        bloodType: doc.bloodType ?? "Unknown",
+        credits: doc.availableCredits ?? 0,
+        units,
+        expiresSoon
+      };
+    });
+
+    const transactionEvents = await transactions
+      .find({ organizationId })
+      .sort({ recordedAt: -1 })
+      .limit(3)
+      .toArray();
+
+    const timeline = [
+      ...transactionEvents.map((txn) => {
+        const recordedAt = safeDate(txn.recordedAt);
+        const at = formatRelativeOrAbsolute(recordedAt);
+        let title = "Ledger activity";
+        let description = `${txn.credits} credits processed`;
+        let status: TimelineItem["status"] = "info";
+
+        if (txn.type === "DONATION") {
+          title = "Donation captured";
+          description = `${txn.credits} credits added to inventory`;
+          status = "success";
+        } else if (txn.type === "REDEMPTION") {
+          title = "Consent fulfilled";
+          description = `${txn.credits} credits redeemed for ${txn.beneficiaryId ?? "beneficiary"}`;
+          status = "info";
+        } else if (txn.type === "EMERGENCY_OVERRIDE") {
+          title = "Emergency override supported";
+          description = `${txn.credits} credits allocated to ${txn.beneficiaryId ?? "beneficiary"}`;
+          status = "warning";
+        }
+
+        return buildTimelineItem({
+          id: txn._id?.toString() ?? randomUUID(),
+          title,
+          description,
+          status,
+          at,
+          sortKey: recordedAt?.getTime()
+        });
+      }),
+      ...recentConsents.map((request) => {
+        const decisionDate = safeDate(request.decidedAt) ?? safeDate(request.requestedAt);
+        const at = formatRelativeOrAbsolute(decisionDate);
+        let title = "Consent request";
+        let status: TimelineItem["status"] = "warning";
+
+        if (request.status === "APPROVED") {
+          title = "Consent approved";
+          status = "success";
+        } else if (request.status === "DECLINED") {
+          title = "Consent declined";
+          status = "error";
+        }
+
+        return buildTimelineItem({
+          id: request._id?.toString() ?? randomUUID(),
+          title,
+          description: `${request.credits} credits for ${request.beneficiaryId ?? "beneficiary"}`,
+          status,
+          at,
+          sortKey: decisionDate?.getTime()
+        });
+      }),
+      ...exchangeEvents.map((exchange) => {
+        const proposedAt = safeDate(exchange.proposedAt);
+        const at = formatRelativeOrAbsolute(proposedAt);
+        const status: TimelineItem["status"] = exchange.status === "PENDING" ? "warning" : "success";
+        const title = exchange.status === "PENDING" ? "Exchange proposed" : "Exchange completed";
+        const description = `${exchange.requestingOrgId} ↔ ${exchange.offeringOrgId} (${exchange.requested?.credits ?? 0}:${
+          exchange.offered?.credits ?? 0
+        })`;
+
+        return buildTimelineItem({
+          id: exchange._id?.toString() ?? randomUUID(),
+          title,
+          description,
+          status,
+          at,
+          sortKey: proposedAt?.getTime()
+        });
+      }),
+      ...inventoryDocs.flatMap((doc) => {
+        const movements = Array.isArray(doc.movements) ? doc.movements : [];
+        return movements.map((movement: any) => {
+          const movementDate = safeDate(movement.at);
+          const at = formatRelativeOrAbsolute(movementDate);
+          const title = movement.type === "FULFILLMENT" ? "Inventory fulfillment" : "Inventory update";
+          const status: TimelineItem["status"] = movement.type === "FULFILLMENT" ? "info" : "success";
+
+          return buildTimelineItem({
+            id: `${doc._id?.toString() ?? doc.bloodType}-${movement.transactionId ?? randomUUID()}`,
+            title,
+            description: `${movement.credits ?? 0} credits · ${doc.bloodType}`,
+            status,
+            at,
+            sortKey: movementDate?.getTime()
+          });
+        });
+      })
+    ]
+      .sort((a, b) => (b.sortKey ?? 0) - (a.sortKey ?? 0))
+      .slice(0, 8)
+      .map(({ sortKey, ...item }) => item);
+
+    return {
+      organization: organization
+        ? {
+            organizationId: organization.organizationId,
+            name: organization.name,
+            status: organization.status,
+            city: organization.city
+          }
+        : undefined,
+      metrics,
+      inventory,
+      timeline
+    };
+  } catch (error) {
+    console.error("Failed to build organization dashboard snapshot", error);
+    return { metrics: [], inventory: [], timeline: [] };
+  }
+}
+
+export async function getDonorDashboardSnapshot(userId: string): Promise<DonorDashboardSnapshot> {
+  try {
+    const { user, recentTransactions } = await getLedgerSummary(userId);
+    const db = await getDatabase();
+
+    const consentRequests = await db
+      .collection("consentRequests")
+      .find({ creditOwnerId: userId, status: "PENDING" })
+      .sort({ requestedAt: -1 })
+      .limit(5)
+      .toArray();
+
+    const pendingCount = consentRequests.length;
+    const balance = user.credits?.balance ?? 0;
+    const earned = user.credits?.totalEarned ?? 0;
+    const redeemed = user.credits?.totalRedeemed ?? 0;
+    const emergency = user.credits?.emergency;
+
+    const metrics: Metric[] = [
+      buildMetric({
+        label: "Current balance",
+        value: `${balance} credits`,
+        change: `${earned} earned · ${redeemed} spent`,
+        tone: balance > 0 ? "neutral" : balance === 0 ? "neutral" : "warning"
+      }),
+      buildMetric({
+        label: "Emergency debt",
+        value: emergency?.active ? `${emergency.credits ?? 0} credits` : "0 credits",
+        change: emergency?.active
+          ? `Due ${formatRelativeOrAbsolute(safeDate(emergency.repaymentDueAt))}`
+          : "In good standing",
+        tone: emergency?.active ? "warning" : "positive"
+      }),
+      buildMetric({
+        label: "Pending requests",
+        value: `${pendingCount}`,
+        change:
+          pendingCount > 0
+            ? `${pendingCount} awaiting your decision`
+            : "No approvals required",
+        tone: pendingCount > 0 ? "warning" : "positive"
+      })
+    ];
+
+    const timeline = recentTransactions.map((txn: any) => {
+      const recordedAt = safeDate(txn.recordedAt);
+      const at = formatRelativeOrAbsolute(recordedAt);
+      let title = "Ledger activity";
+      let description = `${txn.credits} credits`;
+      let status: TimelineItem["status"] = "info";
+
+      if (txn.type === "DONATION") {
+        title = "Donation recorded";
+        description = `${txn.credits} credits donated at ${txn.organizationId}`;
+        status = "success";
+      } else if (txn.type === "REDEMPTION") {
+        title = "Credits redeemed";
+        description = `${txn.credits} credits for ${txn.beneficiaryId ?? "beneficiary"}`;
+        status = "info";
+      } else if (txn.type === "EMERGENCY_OVERRIDE") {
+        title = "Emergency override";
+        description = `${txn.credits} credits advanced by ${txn.organizationId}`;
+        status = "warning";
+      }
+
+      return buildTimelineItem({
+        id: txn._id?.toString() ?? randomUUID(),
+        title,
+        description,
+        status,
+        at,
+        sortKey: recordedAt?.getTime()
+      });
+    });
+
+    const upcoming: TaskItem[] = [];
+
+    consentRequests.forEach((request: any) => {
+      const expiresAt = safeDate(request.expiresAt);
+      upcoming.push(
+        buildTask({
+          id: request._id?.toString() ?? randomUUID(),
+          title: `Review ${request.credits} credit request`,
+          detail: `${request.organizationId} → ${request.beneficiaryId}`,
+          at: expiresAt ? `Expires ${formatRelativeOrAbsolute(expiresAt)}` : undefined
+        })
+      );
+    });
+
+    if (user.eligibility?.nextDonationAt) {
+      const nextDonationAt = safeDate(user.eligibility.nextDonationAt);
+      upcoming.push(
+        buildTask({
+          id: "task-next-donation",
+          title: "Next eligible donation",
+          detail: dateTimeFormatter.format(nextDonationAt ?? new Date()),
+          at: formatRelativeOrAbsolute(nextDonationAt)
+        })
+      );
+    }
+
+    if (emergency?.active) {
+      upcoming.push(
+        buildTask({
+          id: "task-emergency-repayment",
+          title: "Emergency repayment plan",
+          detail: emergency.repaymentPlan ?? "Coordinate with administrators",
+          at: emergency.repaymentDueAt ? dateTimeFormatter.format(safeDate(emergency.repaymentDueAt) ?? new Date()) : undefined
+        })
+      );
+    }
+
+    if (upcoming.length === 0) {
+      upcoming.push(
+        buildTask({
+          id: "task-all-clear",
+          title: "No outstanding tasks",
+          detail: "We will notify you when new consent requests arrive."
+        })
+      );
+    }
+
+    return {
+      donor: {
+        userId: user.userId,
+        name: user.name,
+        bloodType: user.bloodType
+      },
+      metrics,
+      timeline: timeline
+        .sort((a, b) => (b.sortKey ?? 0) - (a.sortKey ?? 0))
+        .map(({ sortKey, ...item }) => item),
+      upcoming
+    };
+  } catch (error) {
+    console.error(`Failed to build donor dashboard snapshot for ${userId}`, error);
+    return { metrics: [], timeline: [], upcoming: [] };
+  }
+}

--- a/lib/dashboard/types.ts
+++ b/lib/dashboard/types.ts
@@ -1,0 +1,84 @@
+export type MetricTone = "positive" | "negative" | "warning" | "neutral";
+
+export type Metric = {
+  label: string;
+  value: string;
+  change?: string;
+  tone?: MetricTone;
+};
+
+export type TimelineStatus = "success" | "warning" | "error" | "info";
+
+export type TimelineItem = {
+  id: string;
+  title: string;
+  description: string;
+  at: string;
+  status?: TimelineStatus;
+};
+
+export type TaskItem = {
+  id: string;
+  title: string;
+  detail?: string;
+  at?: string;
+};
+
+export type AdminDashboardSnapshot = {
+  metrics: Metric[];
+  timeline: TimelineItem[];
+  tasks: TaskItem[];
+};
+
+export type InventoryRow = {
+  bloodType: string;
+  credits: number;
+  units: number;
+  expiresSoon?: boolean;
+};
+
+export type OrganizationDashboardSnapshot = {
+  organization?: {
+    organizationId: string;
+    name?: string;
+    status?: string;
+    city?: string;
+  };
+  metrics: Metric[];
+  inventory: InventoryRow[];
+  timeline: TimelineItem[];
+};
+
+export type DonorDashboardSnapshot = {
+  donor?: {
+    userId: string;
+    name?: string;
+    bloodType?: string;
+  };
+  metrics: Metric[];
+  timeline: TimelineItem[];
+  upcoming: TaskItem[];
+};
+
+export type RiskLevel = "low" | "medium" | "high";
+
+export type RiskItem = {
+  id: string;
+  title: string;
+  detail?: string;
+  severity: RiskLevel;
+};
+
+export type InventoryOverviewRow = {
+  bloodType: string;
+  totalCredits: number;
+  organizations: number;
+  lowStock?: boolean;
+};
+
+export type GovernmentDashboardSnapshot = {
+  metrics: Metric[];
+  timeline: TimelineItem[];
+  risks: RiskItem[];
+  inventory: InventoryOverviewRow[];
+};

--- a/lib/db/mongodb.ts
+++ b/lib/db/mongodb.ts
@@ -1,0 +1,36 @@
+import { MongoClient, type MongoClientOptions } from "mongodb";
+import { config, assertConfig } from "@/lib/config";
+
+declare global {
+  // eslint-disable-next-line no-var
+  var _mongoClientPromise: Promise<MongoClient> | undefined;
+}
+
+const options: MongoClientOptions = {
+  serverSelectionTimeoutMS: 5000
+};
+
+let client: MongoClient;
+let clientPromise: Promise<MongoClient>;
+
+if (process.env.NODE_ENV === "development") {
+  if (!global._mongoClientPromise) {
+    assertConfig();
+    client = new MongoClient(config.mongodbUri, options);
+    global._mongoClientPromise = client.connect();
+  }
+  clientPromise = global._mongoClientPromise;
+} else {
+  assertConfig();
+  client = new MongoClient(config.mongodbUri, options);
+  clientPromise = client.connect();
+}
+
+export async function getMongoClient() {
+  return clientPromise;
+}
+
+export async function getDatabase(dbName = config.mongodbDbName || "bive") {
+  const mongoClient = await getMongoClient();
+  return mongoClient.db(dbName);
+}

--- a/lib/domain/errors.ts
+++ b/lib/domain/errors.ts
@@ -1,0 +1,35 @@
+export class DomainError extends Error {
+  readonly code: string;
+  readonly status: number;
+
+  constructor(message: string, code = "DOMAIN_ERROR", status = 400) {
+    super(message);
+    this.name = this.constructor.name;
+    this.code = code;
+    this.status = status;
+  }
+}
+
+export class NotFoundError extends DomainError {
+  constructor(message: string) {
+    super(message, "NOT_FOUND", 404);
+  }
+}
+
+export class ConflictError extends DomainError {
+  constructor(message: string) {
+    super(message, "CONFLICT", 409);
+  }
+}
+
+export class InsufficientCreditsError extends DomainError {
+  constructor(message: string) {
+    super(message, "INSUFFICIENT_CREDITS", 409);
+  }
+}
+
+export class UnauthorizedError extends DomainError {
+  constructor(message = "Authentication required") {
+    super(message, "UNAUTHORIZED", 401);
+  }
+}

--- a/lib/domain/schemas.ts
+++ b/lib/domain/schemas.ts
@@ -1,0 +1,86 @@
+import { z } from "zod";
+
+export const bloodTypeSchema = z.enum([
+  "A+",
+  "A-",
+  "B+",
+  "B-",
+  "AB+",
+  "AB-",
+  "O+",
+  "O-"
+]);
+
+export const bloodComponentSchema = z.enum([
+  "whole_blood",
+  "packed_rbc",
+  "plasma",
+  "platelets",
+  "cryoprecipitate"
+]);
+
+const objectIdLike = z.string().min(1, "id is required");
+
+export const donationInputSchema = z.object({
+  donorId: objectIdLike,
+  organizationId: objectIdLike,
+  bloodType: bloodTypeSchema,
+  component: bloodComponentSchema,
+  credits: z.number().int().positive(),
+  volumeMl: z.number().int().positive().optional(),
+  collectedAt: z.coerce.date().optional(),
+  notes: z.string().max(1000).optional()
+});
+
+export const consentRequestSchema = z.object({
+  creditOwnerId: objectIdLike,
+  beneficiaryId: objectIdLike,
+  organizationId: objectIdLike,
+  credits: z.number().int().positive(),
+  expiresAt: z.coerce.date().optional(),
+  context: z
+    .object({
+      requestedBloodType: bloodTypeSchema.optional(),
+      reason: z.string().max(2000).optional(),
+      clinicalNotes: z.string().max(2000).optional()
+    })
+    .partial()
+    .optional()
+});
+
+export const consentDecisionSchema = z.object({
+  actorId: objectIdLike,
+  decision: z.enum(["approve", "decline"]),
+  note: z.string().max(2000).optional()
+});
+
+export const emergencyOverrideSchema = z.object({
+  beneficiaryId: objectIdLike,
+  organizationId: objectIdLike,
+  initiatedBy: objectIdLike,
+  credits: z.number().int().positive(),
+  justification: z.string().max(2000),
+  repaymentPlan: z.string().max(2000).optional(),
+  repaymentDueAt: z.coerce.date().optional(),
+  debtCeilingCredits: z.number().int().positive()
+});
+
+export const exchangeProposalSchema = z.object({
+  requestingOrgId: objectIdLike,
+  offeringOrgId: objectIdLike,
+  requested: z.object({
+    bloodType: bloodTypeSchema,
+    credits: z.number().int().positive()
+  }),
+  offered: z.object({
+    bloodType: bloodTypeSchema,
+    credits: z.number().int().positive()
+  }),
+  notes: z.string().max(2000).optional()
+});
+
+export type DonationInput = z.infer<typeof donationInputSchema>;
+export type ConsentRequestInput = z.infer<typeof consentRequestSchema>;
+export type ConsentDecisionInput = z.infer<typeof consentDecisionSchema>;
+export type EmergencyOverrideInput = z.infer<typeof emergencyOverrideSchema>;
+export type ExchangeProposalInput = z.infer<typeof exchangeProposalSchema>;

--- a/lib/domain/services.ts
+++ b/lib/domain/services.ts
@@ -1,0 +1,420 @@
+import { randomUUID } from "crypto";
+import type { ClientSession, Db } from "mongodb";
+
+import { getDatabase, getMongoClient } from "@/lib/db/mongodb";
+import {
+  consentDecisionSchema,
+  consentRequestSchema,
+  donationInputSchema,
+  emergencyOverrideSchema,
+  exchangeProposalSchema,
+  type ConsentDecisionInput,
+  type ConsentRequestInput,
+  type DonationInput,
+  type EmergencyOverrideInput,
+  type ExchangeProposalInput
+} from "./schemas";
+import {
+  ConflictError,
+  DomainError,
+  InsufficientCreditsError,
+  NotFoundError
+} from "./errors";
+
+type CollectionMap = {
+  users: ReturnType<Db["collection"]>;
+  transactions: ReturnType<Db["collection"]>;
+  consentRequests: ReturnType<Db["collection"]>;
+  inventory: ReturnType<Db["collection"]>;
+  emergencyCases: ReturnType<Db["collection"]>;
+  exchanges: ReturnType<Db["collection"]>;
+};
+
+async function withCollections() {
+  const db = await getDatabase();
+  const collections: CollectionMap = {
+    users: db.collection("users"),
+    transactions: db.collection("transactions"),
+    consentRequests: db.collection("consentRequests"),
+    inventory: db.collection("inventory"),
+    emergencyCases: db.collection("emergencyCases"),
+    exchanges: db.collection("exchanges")
+  };
+
+  return { db, collections };
+}
+
+async function runInTransaction<T>(handler: (deps: { db: Db; collections: CollectionMap; session: ClientSession }) => Promise<T>) {
+  const client = await getMongoClient();
+  const session = client.startSession();
+
+  try {
+    let result: T | undefined;
+    await session.withTransaction(async () => {
+      const deps = await withCollections();
+      result = await handler({ ...deps, session });
+    });
+    if (typeof result === "undefined") {
+      throw new DomainError("Transaction did not return a result");
+    }
+    return result;
+  } finally {
+    await session.endSession();
+  }
+}
+
+export async function recordDonation(input: DonationInput) {
+  const data = donationInputSchema.parse(input);
+  const recordedAt = new Date();
+  const collectedAt = data.collectedAt ?? recordedAt;
+
+  return runInTransaction(async ({ collections, session }) => {
+    const transactionId = randomUUID();
+
+    const donationDoc = {
+      _id: transactionId,
+      type: "DONATION" as const,
+      donorId: data.donorId,
+      organizationId: data.organizationId,
+      credits: data.credits,
+      volumeMl: data.volumeMl ?? data.credits * 100,
+      component: data.component,
+      bloodType: data.bloodType,
+      collectedAt,
+      recordedAt,
+      notes: data.notes ?? null
+    };
+
+    const donorUpdate = await collections.users.updateOne(
+      { userId: data.donorId },
+      {
+        $inc: {
+          "credits.balance": data.credits,
+          "credits.totalEarned": data.credits
+        },
+        $push: {
+          "credits.events": {
+            type: "DONATION",
+            credits: data.credits,
+            organizationId: data.organizationId,
+            transactionId,
+            at: recordedAt
+          }
+        }
+      },
+      { session }
+    );
+
+    if (donorUpdate.matchedCount === 0) {
+      throw new NotFoundError("Donor profile not found");
+    }
+
+    await collections.transactions.insertOne(donationDoc, { session });
+
+    await collections.inventory.updateOne(
+      { organizationId: data.organizationId, bloodType: data.bloodType },
+      {
+        $setOnInsert: {
+          organizationId: data.organizationId,
+          bloodType: data.bloodType,
+          createdAt: recordedAt
+        },
+        $set: { updatedAt: recordedAt },
+        $inc: {
+          availableCredits: data.credits,
+          totalDonatedCredits: data.credits
+        },
+        $push: {
+          movements: {
+            type: "DONATION",
+            credits: data.credits,
+            transactionId,
+            at: recordedAt
+          }
+        }
+      },
+      { session, upsert: true }
+    );
+
+    return { transactionId };
+  });
+}
+
+export async function createConsentRequest(input: ConsentRequestInput) {
+  const data = consentRequestSchema.parse(input);
+  const requestedAt = new Date();
+  const requestId = randomUUID();
+
+  const document = {
+    _id: requestId,
+    status: "PENDING" as const,
+    ...data,
+    context: data.context ?? {},
+    requestedAt
+  };
+
+  const db = await getDatabase();
+  const { insertedId } = await db.collection("consentRequests").insertOne(document);
+
+  return { requestId: insertedId.toString(), status: document.status, requestedAt };
+}
+
+export async function respondToConsentRequest(requestId: string, decisionInput: ConsentDecisionInput) {
+  const decision = consentDecisionSchema.parse(decisionInput);
+
+  return runInTransaction(async ({ collections, session }) => {
+    const request = await collections.consentRequests.findOne({ _id: requestId }, { session });
+
+    if (!request) {
+      throw new NotFoundError("Consent request not found");
+    }
+
+    if (request.status !== "PENDING") {
+      throw new ConflictError("Consent request already resolved");
+    }
+
+    const resolvedAt = new Date();
+    const newStatus = decision.decision === "approve" ? "APPROVED" : "DECLINED";
+
+    const update = await collections.consentRequests.findOneAndUpdate(
+      { _id: requestId },
+      {
+        $set: {
+          status: newStatus,
+          decidedBy: decision.actorId,
+          decisionNote: decision.note ?? null,
+          decidedAt: resolvedAt
+        }
+      },
+      { session, returnDocument: "after" }
+    );
+
+    if (!update.value) {
+      throw new DomainError("Failed to update consent request");
+    }
+
+    if (newStatus === "APPROVED") {
+      const owner = await collections.users.findOne({ userId: request.creditOwnerId }, { session });
+
+      if (!owner) {
+        throw new NotFoundError("Credit owner not found");
+      }
+
+      const currentBalance = owner.credits?.balance ?? 0;
+      if (currentBalance < request.credits) {
+        throw new InsufficientCreditsError("Insufficient credits for approval");
+      }
+
+      const transactionId = randomUUID();
+      const recordedAt = resolvedAt;
+
+      await collections.users.updateOne(
+        { userId: request.creditOwnerId },
+        {
+          $inc: {
+            "credits.balance": -request.credits,
+            "credits.totalRedeemed": request.credits
+          },
+          $push: {
+            "credits.events": {
+              type: "REDEMPTION",
+              credits: request.credits,
+              organizationId: request.organizationId,
+              transactionId,
+              beneficiaryId: request.beneficiaryId,
+              at: recordedAt
+            }
+          }
+        },
+        { session }
+      );
+
+      await collections.transactions.insertOne(
+        {
+          _id: transactionId,
+          type: "REDEMPTION",
+          creditOwnerId: request.creditOwnerId,
+          beneficiaryId: request.beneficiaryId,
+          organizationId: request.organizationId,
+          credits: request.credits,
+          consentRequestId: requestId,
+          recordedAt
+        },
+        { session }
+      );
+
+      if (request.context?.requestedBloodType) {
+        await collections.inventory.updateOne(
+          { organizationId: request.organizationId, bloodType: request.context.requestedBloodType },
+          {
+            $set: { updatedAt: recordedAt },
+            $inc: { availableCredits: -request.credits },
+            $push: {
+              movements: {
+                type: "FULFILLMENT",
+                credits: request.credits,
+                consentRequestId: requestId,
+                at: recordedAt
+              }
+            }
+          },
+          { session }
+        );
+      }
+    }
+
+    return { request: update.value };
+  });
+}
+
+export async function applyEmergencyOverride(input: EmergencyOverrideInput) {
+  const data = emergencyOverrideSchema.parse(input);
+  const initiatedAt = new Date();
+
+  return runInTransaction(async ({ collections, session }) => {
+    const user = await collections.users.findOne({ userId: data.beneficiaryId }, { session });
+
+    if (!user) {
+      throw new NotFoundError("Beneficiary not found");
+    }
+
+    const currentBalance = user.credits?.balance ?? 0;
+    if (currentBalance < 0) {
+      throw new ConflictError("Beneficiary already has an outstanding emergency debt");
+    }
+
+    const projectedBalance = currentBalance - data.credits;
+    if (Math.abs(projectedBalance) > data.debtCeilingCredits) {
+      throw new ConflictError("Emergency request exceeds configured debt ceiling");
+    }
+
+    const transactionId = randomUUID();
+
+    await collections.users.updateOne(
+      { userId: data.beneficiaryId },
+      {
+        $inc: {
+          "credits.balance": -data.credits,
+          "credits.totalRedeemed": data.credits
+        },
+        $set: {
+          "credits.emergency": {
+            active: true,
+            overrideId: transactionId,
+            credits: data.credits,
+            initiatedAt,
+            organizationId: data.organizationId,
+            justification: data.justification,
+            repaymentPlan: data.repaymentPlan ?? null,
+            repaymentDueAt: data.repaymentDueAt ?? null
+          }
+        },
+        $push: {
+          "credits.events": {
+            type: "EMERGENCY_OVERRIDE",
+            credits: data.credits,
+            organizationId: data.organizationId,
+            transactionId,
+            at: initiatedAt
+          }
+        }
+      },
+      { session }
+    );
+
+    await collections.transactions.insertOne(
+      {
+        _id: transactionId,
+        type: "EMERGENCY_OVERRIDE",
+        beneficiaryId: data.beneficiaryId,
+        organizationId: data.organizationId,
+        initiatedBy: data.initiatedBy,
+        credits: data.credits,
+        justification: data.justification,
+        repaymentPlan: data.repaymentPlan ?? null,
+        repaymentDueAt: data.repaymentDueAt ?? null,
+        recordedAt: initiatedAt
+      },
+      { session }
+    );
+
+    await collections.emergencyCases.insertOne(
+      {
+        _id: transactionId,
+        beneficiaryId: data.beneficiaryId,
+        organizationId: data.organizationId,
+        initiatedBy: data.initiatedBy,
+        credits: data.credits,
+        status: "OUTSTANDING",
+        justification: data.justification,
+        repaymentPlan: data.repaymentPlan ?? null,
+        repaymentDueAt: data.repaymentDueAt ?? null,
+        createdAt: initiatedAt,
+        updatedAt: initiatedAt
+      },
+      { session }
+    );
+
+    return { transactionId };
+  });
+}
+
+export async function createExchangeProposal(input: ExchangeProposalInput) {
+  const data = exchangeProposalSchema.parse(input);
+  const proposedAt = new Date();
+  const exchangeId = randomUUID();
+
+  const doc = {
+    _id: exchangeId,
+    status: "PENDING" as const,
+    ...data,
+    proposedAt
+  };
+
+  const db = await getDatabase();
+  await db.collection("exchanges").insertOne(doc);
+
+  return { exchangeId, status: doc.status, proposedAt };
+}
+
+export async function getLedgerSummary(userId: string) {
+  const db = await getDatabase();
+
+  const projection = {
+    _id: 0,
+    userId: 1,
+    name: 1,
+    bloodType: 1,
+    "credits.balance": 1,
+    "credits.totalEarned": 1,
+    "credits.totalRedeemed": 1,
+    "credits.emergency": 1
+  };
+
+  const user = await db.collection("users").findOne({ userId }, { projection });
+
+  if (!user) {
+    throw new NotFoundError("User not found");
+  }
+
+  const transactions = await db
+    .collection("transactions")
+    .find({ $or: [{ donorId: userId }, { creditOwnerId: userId }, { beneficiaryId: userId }] })
+    .sort({ recordedAt: -1 })
+    .limit(50)
+    .toArray();
+
+  return { user, recentTransactions: transactions };
+}
+
+export async function getInventoryForOrganization(organizationId: string) {
+  const db = await getDatabase();
+
+  const inventory = await db
+    .collection("inventory")
+    .find({ organizationId })
+    .project({ _id: 0, organizationId: 1, bloodType: 1, availableCredits: 1, updatedAt: 1 })
+    .toArray();
+
+  return { organizationId, inventory };
+}

--- a/next-auth.d.ts
+++ b/next-auth.d.ts
@@ -1,0 +1,24 @@
+import type { DefaultSession } from "next-auth";
+
+declare module "next-auth" {
+  interface Session {
+    user?: DefaultSession["user"] & {
+      id: string;
+      roles: string[];
+      organizationId?: string;
+    };
+  }
+
+  interface User {
+    id: string;
+    roles: string[];
+    organizationId?: string;
+  }
+}
+
+declare module "next-auth/jwt" {
+  interface JWT {
+    roles?: string[];
+    organizationId?: string;
+  }
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    serverActions: true
+  }
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "b-ive-platform",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "seed": "node scripts/seed.mjs"
+  },
+  "dependencies": {
+    "bcryptjs": "^2.4.3",
+    "mongodb": "^6.7.0",
+    "next": "^14.2.4",
+    "next-auth": "^4.24.6",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-markdown": "^9.0.1",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/node": "^20.12.12",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "autoprefixer": "^10.4.19",
+    "eslint": "^8.57.0",
+    "eslint-config-next": "^14.2.4",
+    "postcss": "^8.4.38",
+    "tailwindcss": "^3.4.3",
+    "typescript": "^5.4.5"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/scripts/seed.mjs
+++ b/scripts/seed.mjs
@@ -1,0 +1,485 @@
+import { randomUUID } from "crypto";
+import { MongoClient } from "mongodb";
+import bcrypt from "bcryptjs";
+
+const uri = process.env.MONGODB_URI;
+const dbName = process.env.MONGODB_DB_NAME || "bive";
+
+if (!uri) {
+  console.error("Missing MONGODB_URI. Set it before running the seed script.");
+  process.exit(1);
+}
+
+const client = new MongoClient(uri, {
+  serverSelectionTimeoutMS: 5000
+});
+
+const now = new Date();
+
+const hoursAgo = (hours) => new Date(now.getTime() - hours * 60 * 60 * 1000);
+const hoursFromNow = (hours) => new Date(now.getTime() + hours * 60 * 60 * 1000);
+
+const donationTransactionId = "txn-donation-001";
+const redemptionTransactionId = "txn-redemption-001";
+const emergencyTransactionId = "txn-emergency-001";
+
+const DEMO_PASSWORD = "ChangeMe123!";
+
+const baseUsers = [
+  {
+    demoSeed: true,
+    userId: "user-donor-001",
+    name: "Ritu Sharma",
+    roles: ["donor"],
+    authEmail: "ritu.sharma@example.com",
+    bloodType: "B+",
+    contact: {
+      email: "ritu.sharma@example.com",
+      phone: "+91-90000-00001",
+      city: "Delhi"
+    },
+    credits: {
+      balance: 14,
+      totalEarned: 24,
+      totalRedeemed: 10,
+      events: [
+        {
+          type: "DONATION",
+          credits: 4,
+          organizationId: "org-sunrise",
+          transactionId: donationTransactionId,
+          at: hoursAgo(24 * 7)
+        },
+        {
+          type: "REDEMPTION",
+          credits: 2,
+          organizationId: "org-sunrise",
+          beneficiaryId: "user-beneficiary-001",
+          transactionId: redemptionTransactionId,
+          at: hoursAgo(12)
+        }
+      ],
+      emergency: { active: false }
+    },
+    eligibility: {
+      lastDonationAt: hoursAgo(24 * 7),
+      nextDonationAt: hoursFromNow(24 * 10)
+    }
+  },
+  {
+    demoSeed: true,
+    userId: "user-beneficiary-001",
+    name: "Arjun Patel",
+    roles: ["recipient"],
+    authEmail: "arjun.patel@example.com",
+    bloodType: "A+",
+    contact: {
+      email: "arjun.patel@example.com",
+      phone: "+91-90000-00002",
+      city: "Mumbai"
+    },
+    credits: {
+      balance: 0,
+      totalEarned: 0,
+      totalRedeemed: 2,
+      events: [
+        {
+          type: "REDEMPTION",
+          credits: 2,
+          organizationId: "org-sunrise",
+          transactionId: redemptionTransactionId,
+          at: hoursAgo(12)
+        }
+      ]
+    }
+  },
+  {
+    demoSeed: true,
+    userId: "user-beneficiary-002",
+    name: "Rahul Iyer",
+    roles: ["recipient"],
+    authEmail: "rahul.iyer@example.com",
+    bloodType: "A+",
+    contact: {
+      email: "rahul.iyer@example.com",
+      phone: "+91-90000-00004",
+      city: "Pune"
+    },
+    credits: {
+      balance: 0,
+      totalEarned: 0,
+      totalRedeemed: 0,
+      events: []
+    }
+  },
+  {
+    demoSeed: true,
+    userId: "user-beneficiary-urgent",
+    name: "Neha Verma",
+    roles: ["recipient"],
+    authEmail: "neha.verma@example.com",
+    bloodType: "O-",
+    contact: {
+      email: "neha.verma@example.com",
+      phone: "+91-90000-00003",
+      city: "Jaipur"
+    },
+    credits: {
+      balance: -3,
+      totalEarned: 0,
+      totalRedeemed: 3,
+      emergency: {
+        active: true,
+        overrideId: emergencyTransactionId,
+        credits: 3,
+        initiatedAt: hoursAgo(6),
+        organizationId: "org-red-valley",
+        justification: "Post-operative emergency transfusion",
+        repaymentPlan: "Family to donate equivalent credits within 30 days",
+        repaymentDueAt: hoursFromNow(24 * 20)
+      },
+      events: [
+        {
+          type: "EMERGENCY_OVERRIDE",
+          credits: 3,
+          organizationId: "org-red-valley",
+          transactionId: emergencyTransactionId,
+          at: hoursAgo(6)
+        }
+      ]
+    }
+  }
+];
+
+const controlUsers = [
+  {
+    demoSeed: true,
+    userId: "admin-global",
+    name: "Platform Admin",
+    roles: ["admin"],
+    authEmail: "admin@bive.demo",
+    contact: {
+      email: "admin@bive.demo",
+      phone: "+91-90000-90001",
+      city: "Delhi"
+    }
+  },
+  {
+    demoSeed: true,
+    userId: "gov-national",
+    name: "Gov Oversight",
+    roles: ["government"],
+    authEmail: "gov@bive.demo",
+    contact: {
+      email: "gov@bive.demo",
+      phone: "+91-90000-90002",
+      city: "New Delhi"
+    }
+  },
+  {
+    demoSeed: true,
+    userId: "org-sunrise-admin",
+    name: "Sunrise Ops",
+    roles: ["organization"],
+    authEmail: "org@bive.demo",
+    organizationId: "org-sunrise",
+    contact: {
+      email: "org@bive.demo",
+      phone: "+91-90000-90003",
+      city: "Delhi"
+    }
+  }
+];
+
+async function buildUsers() {
+  const passwordHash = await bcrypt.hash(DEMO_PASSWORD, 10);
+  return [...baseUsers, ...controlUsers].map(({ authEmail, ...user }) => ({
+    ...user,
+    auth: {
+      email: authEmail ?? user.contact?.email ?? `${user.userId}@bive.demo`,
+      passwordHash
+    }
+  }));
+}
+
+const organizations = [
+  {
+    demoSeed: true,
+    organizationId: "org-sunrise",
+    name: "Sunrise Hospital",
+    city: "Delhi",
+    status: "active",
+    verifiedAt: hoursAgo(24 * 30),
+    contact: {
+      email: "ops@sunrise-hospital.example.com",
+      phone: "+91-90000-10001"
+    },
+    compliance: {
+      licenseNumber: "DL-2024-001",
+      licenseExpiry: hoursFromNow(24 * 240)
+    }
+  },
+  {
+    demoSeed: true,
+    organizationId: "org-red-valley",
+    name: "Red Valley Hospital",
+    city: "Jaipur",
+    status: "active",
+    verifiedAt: hoursAgo(24 * 20),
+    contact: {
+      email: "transfusion@redvalley.example.com",
+      phone: "+91-90000-10002"
+    }
+  },
+  {
+    demoSeed: true,
+    organizationId: "org-green-cross",
+    name: "Green Cross Blood Center",
+    city: "Lucknow",
+    status: "pending",
+    submittedAt: hoursAgo(24 * 2),
+    contact: {
+      email: "director@greencross.example.com",
+      phone: "+91-90000-10003"
+    }
+  }
+];
+
+const transactions = [
+  {
+    _id: donationTransactionId,
+    demoSeed: true,
+    type: "DONATION",
+    donorId: "user-donor-001",
+    organizationId: "org-sunrise",
+    credits: 4,
+    volumeMl: 400,
+    component: "whole_blood",
+    bloodType: "B+",
+    recordedAt: hoursAgo(24 * 7)
+  },
+  {
+    _id: redemptionTransactionId,
+    demoSeed: true,
+    type: "REDEMPTION",
+    creditOwnerId: "user-donor-001",
+    beneficiaryId: "user-beneficiary-001",
+    organizationId: "org-sunrise",
+    credits: 2,
+    consentRequestId: "req-1000",
+    recordedAt: hoursAgo(12)
+  },
+  {
+    _id: emergencyTransactionId,
+    demoSeed: true,
+    type: "EMERGENCY_OVERRIDE",
+    beneficiaryId: "user-beneficiary-urgent",
+    organizationId: "org-red-valley",
+    initiatedBy: "admin-global",
+    credits: 3,
+    justification: "Post-operative emergency transfusion",
+    repaymentPlan: "Family to replenish credits in 30 days",
+    repaymentDueAt: hoursFromNow(24 * 20),
+    recordedAt: hoursAgo(6)
+  }
+];
+
+const inventory = [
+  {
+    demoSeed: true,
+    organizationId: "org-sunrise",
+    bloodType: "B+",
+    availableCredits: 24,
+    availableUnits: 12,
+    totalDonatedCredits: 48,
+    nextExpiryAt: hoursFromNow(24 * 2),
+    movements: [
+      {
+        type: "DONATION",
+        credits: 4,
+        transactionId: donationTransactionId,
+        at: hoursAgo(24 * 7)
+      },
+      {
+        type: "FULFILLMENT",
+        credits: 2,
+        consentRequestId: "req-1000",
+        at: hoursAgo(12)
+      }
+    ]
+  },
+  {
+    demoSeed: true,
+    organizationId: "org-sunrise",
+    bloodType: "O-",
+    availableCredits: 10,
+    availableUnits: 5,
+    totalDonatedCredits: 18,
+    nextExpiryAt: hoursFromNow(24 * 5),
+    movements: [
+      {
+        type: "DONATION",
+        credits: 5,
+        transactionId: randomUUID(),
+        at: hoursAgo(24 * 3)
+      }
+    ]
+  },
+  {
+    demoSeed: true,
+    organizationId: "org-red-valley",
+    bloodType: "O-",
+    availableCredits: 6,
+    availableUnits: 3,
+    totalDonatedCredits: 20,
+    nextExpiryAt: hoursFromNow(24),
+    movements: [
+      {
+        type: "EMERGENCY_OVERRIDE",
+        credits: 3,
+        transactionId: emergencyTransactionId,
+        at: hoursAgo(6)
+      }
+    ]
+  }
+];
+
+const consentRequests = [
+  {
+    _id: "req-1000",
+    demoSeed: true,
+    status: "APPROVED",
+    creditOwnerId: "user-donor-001",
+    beneficiaryId: "user-beneficiary-001",
+    organizationId: "org-sunrise",
+    credits: 2,
+    requestedAt: hoursAgo(18),
+    decidedAt: hoursAgo(12),
+    decidedBy: "user-donor-001",
+    context: {
+      requestedBloodType: "A+",
+      reason: "Planned surgery"
+    }
+  },
+  {
+    _id: "req-1001",
+    demoSeed: true,
+    status: "PENDING",
+    creditOwnerId: "user-donor-001",
+    beneficiaryId: "user-beneficiary-002",
+    organizationId: "org-sunrise",
+    credits: 2,
+    requestedAt: hoursAgo(1),
+    expiresAt: hoursFromNow(3),
+    context: {
+      requestedBloodType: "A+",
+      reason: "Platelet support",
+      clinicalNotes: "Urgent oncology procedure"
+    }
+  }
+];
+
+const emergencyCases = [
+  {
+    _id: emergencyTransactionId,
+    demoSeed: true,
+    beneficiaryId: "user-beneficiary-urgent",
+    organizationId: "org-red-valley",
+    initiatedBy: "admin-global",
+    credits: 3,
+    status: "OUTSTANDING",
+    justification: "Post-operative emergency transfusion",
+    repaymentPlan: "Family to replenish credits in 30 days",
+    repaymentDueAt: hoursFromNow(24 * 20),
+    createdAt: hoursAgo(6),
+    updatedAt: hoursAgo(6)
+  }
+];
+
+const exchanges = [
+  {
+    _id: "ex-2001",
+    demoSeed: true,
+    requestingOrgId: "org-sunrise",
+    offeringOrgId: "org-red-valley",
+    requested: {
+      bloodType: "O-",
+      credits: 2
+    },
+    offered: {
+      bloodType: "A+",
+      credits: 3
+    },
+    status: "PENDING",
+    proposedAt: hoursAgo(4),
+    notes: "Balance differential once transport confirmed"
+  },
+  {
+    _id: "ex-2002",
+    demoSeed: true,
+    requestingOrgId: "org-red-valley",
+    offeringOrgId: "org-sunrise",
+    requested: {
+      bloodType: "B+",
+      credits: 2
+    },
+    offered: {
+      bloodType: "O-",
+      credits: 2
+    },
+    status: "COMPLETED",
+    proposedAt: hoursAgo(48),
+    completedAt: hoursAgo(30)
+  }
+];
+
+async function seed() {
+  await client.connect();
+  const db = client.db(dbName);
+  const users = await buildUsers();
+
+  await Promise.all([
+    db.collection("users").createIndex({ userId: 1 }, { unique: true }),
+    db.collection("organizations").createIndex({ organizationId: 1 }, { unique: true }),
+    db.collection("transactions").createIndex({ recordedAt: -1 }),
+    db.collection("consentRequests").createIndex({ status: 1, requestedAt: -1 }),
+    db.collection("inventory").createIndex({ organizationId: 1, bloodType: 1 }, { unique: true })
+  ]);
+
+  await Promise.all([
+    db.collection("users").deleteMany({ demoSeed: true }),
+    db.collection("organizations").deleteMany({ demoSeed: true }),
+    db.collection("transactions").deleteMany({ demoSeed: true }),
+    db.collection("consentRequests").deleteMany({ demoSeed: true }),
+    db.collection("inventory").deleteMany({ demoSeed: true }),
+    db.collection("emergencyCases").deleteMany({ demoSeed: true }),
+    db.collection("exchanges").deleteMany({ demoSeed: true })
+  ]);
+
+  await db.collection("users").insertMany(users);
+  await db.collection("organizations").insertMany(organizations);
+  await db.collection("transactions").insertMany(transactions);
+  await db.collection("inventory").insertMany(inventory);
+  await db.collection("consentRequests").insertMany(consentRequests);
+  await db.collection("emergencyCases").insertMany(emergencyCases);
+  await db.collection("exchanges").insertMany(exchanges);
+
+  console.log("Seed data loaded successfully.");
+  console.log("  Users:", users.length);
+  console.log("  Organizations:", organizations.length);
+  console.log("  Transactions:", transactions.length);
+  console.log("  Consent requests:", consentRequests.length);
+  console.log("  Emergency cases:", emergencyCases.length);
+  console.log("  Exchanges:", exchanges.length);
+  console.log("  Default password:", DEMO_PASSWORD);
+  console.log("  Demo admins:", controlUsers.map((user) => user.authEmail).join(", "));
+}
+
+seed()
+  .catch((error) => {
+    console.error("Failed to seed MongoDB:", error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await client.close();
+  });

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,24 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: [
+    "./app/**/*.{ts,tsx}",
+    "./components/**/*.{ts,tsx}",
+    "./pages/**/*.{ts,tsx}",
+    "./src/**/*.{ts,tsx}"
+  ],
+  theme: {
+    extend: {
+      colors: {
+        brand: {
+          primary: "#C1121F",
+          dark: "#780000",
+          accent: "#FFCCD5"
+        }
+      }
+    }
+  },
+  plugins: []
+};
+
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/components/*": ["components/*"],
+      "@/lib/*": ["lib/*"],
+      "@/app/*": ["app/*"]
+    },
+    "types": ["node", "next-auth"]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.cjs", "**/*.mjs"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- integrate NextAuth credential authentication with a custom login page, session provider, and navigation updates
- guard workspace routes and dashboard navigation by user roles while tightening action forms and highlights to current permissions
- require authenticated sessions for ledger, inventory, consent, donation, emergency, and exchange APIs and seed hashed demo accounts with shared credentials
- add a government observatory workspace backed by new dashboard queries, risk scoring, and inventory coverage, and surface it in the navigation and README

## Testing
- Not run (npm install is blocked in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68d8f6e415148331b4916a59c031d3f6